### PR TITLE
Remove `custom_image_*` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ With this provider you can manage Argo CD instances and clusters on [Akuity Plat
     required_providers {
       akp = {
         source = "akuity/akp"
-        version = "~> 0.3"
+        version = "~> 0.4"
       }
     }
   }

--- a/akp/data_source_akp_cluster.go
+++ b/akp/data_source_akp_cluster.go
@@ -71,14 +71,6 @@ func (d *AkpClusterDataSource) Schema(ctx context.Context, req datasource.Schema
 				MarkdownDescription: "Disable Agents Auto Upgrade",
 				Computed:            true,
 			},
-			"custom_image_registry_argoproj": schema.StringAttribute{
-				MarkdownDescription: "Custom Registry for Argoproj Images",
-				Computed:            true,
-			},
-			"custom_image_registry_akuity": schema.StringAttribute{
-				MarkdownDescription: "Custom Registry for Akuity Images",
-				Computed:            true,
-			},
 			"labels": schema.MapAttribute{
 				ElementType: types.StringType,
 				MarkdownDescription: "Cluster Labels",

--- a/akp/data_source_akp_clusters.go
+++ b/akp/data_source_akp_clusters.go
@@ -88,14 +88,6 @@ func (d *AkpClustersDataSource) Schema(ctx context.Context, req datasource.Schem
 							MarkdownDescription: "Disable Agents Auto Upgrade",
 							Computed:            true,
 						},
-						"custom_image_registry_argoproj": schema.StringAttribute{
-							MarkdownDescription: "Custom Registry for Argoproj Images",
-							Computed:            true,
-						},
-						"custom_image_registry_akuity": schema.StringAttribute{
-							MarkdownDescription: "Custom Registry for Akuity Images",
-							Computed:            true,
-						},
 						"labels": schema.MapAttribute{
 							ElementType:         types.StringType,
 							MarkdownDescription: "Cluster Labels",

--- a/akp/data_source_akp_instance.go
+++ b/akp/data_source_akp_instance.go
@@ -224,14 +224,6 @@ func (d *AkpInstanceDataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "Default Values For Cluster Agents",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"custom_image_registry_argoproj": schema.StringAttribute{
-						MarkdownDescription: "Custom Image Registry for Argoproj images",
-						Computed:            true,
-					},
-					"custom_image_registry_akuity": schema.StringAttribute{
-						MarkdownDescription: "Custom Image Registry for Akuity images",
-						Computed:            true,
-					},
 					"auto_upgrade_disabled": schema.BoolAttribute{
 						MarkdownDescription: "Disable Agent Auto-upgrade",
 						Computed:            true,

--- a/akp/data_source_akp_instances.go
+++ b/akp/data_source_akp_instances.go
@@ -235,14 +235,6 @@ func (d *AkpInstancesDataSource) Schema(ctx context.Context, req datasource.Sche
 							MarkdownDescription: "Default Values For Cluster Agents",
 							Computed:            true,
 							Attributes: map[string]schema.Attribute{
-								"custom_image_registry_argoproj": schema.StringAttribute{
-									MarkdownDescription: "Custom Image Registry for Argoproj images",
-									Computed:            true,
-								},
-								"custom_image_registry_akuity": schema.StringAttribute{
-									MarkdownDescription: "Custom Image Registry for Akuity images",
-									Computed:            true,
-								},
 								"auto_upgrade_disabled": schema.BoolAttribute{
 									MarkdownDescription: "Disable Agent Auto-upgrade",
 									Computed:            true,

--- a/akp/resource_akp_cluster.go
+++ b/akp/resource_akp_cluster.go
@@ -192,8 +192,6 @@ func (r *AkpClusterResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	ctx = ctxutil.SetClientCredential(ctx, r.akpCli.Cred)
-	customArgoproj := plan.CustomImageRegistryArgoproj.ValueString()
-	customAkuity := plan.CustomImageRegistryAkuity.ValueString()
 	autoupgrade := plan.AutoUpgradeDisabled.ValueBool()
 	var labels map[string]string
 	var annotations map[string]string
@@ -208,8 +206,6 @@ func (r *AkpClusterResource) Create(ctx context.Context, req resource.CreateRequ
 		NamespaceScoped: plan.NamespaceScoped.ValueBool(),
 		Data: &argocdv1.ClusterData{
 			Size:                        akptypes.StringClusterSize[plan.Size.ValueString()],
-			CustomImageRegistryArgoproj: &customArgoproj,
-			CustomImageRegistryAkuity:   &customAkuity,
 			AutoUpgradeDisabled:         &autoupgrade,
 			Labels:                      labels,
 			Annotations:                 annotations,
@@ -308,8 +304,6 @@ func (r *AkpClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	ctx = ctxutil.SetClientCredential(ctx, r.akpCli.Cred)
-	customArgoproj := plan.CustomImageRegistryArgoproj.ValueString()
-	customAkuity := plan.CustomImageRegistryAkuity.ValueString()
 	autoupgrade := plan.AutoUpgradeDisabled.ValueBool()
 	var labels map[string]string
 	var annotations map[string]string
@@ -322,8 +316,6 @@ func (r *AkpClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		Description:    plan.Description.ValueString(),
 		Data: &argocdv1.ClusterData{
 			Size:                        akptypes.StringClusterSize[plan.Size.ValueString()],
-			CustomImageRegistryArgoproj: &customArgoproj,
-			CustomImageRegistryAkuity:   &customAkuity,
 			AutoUpgradeDisabled:         &autoupgrade,
 			Labels:                      labels,
 			Annotations:                 annotations,

--- a/akp/resource_akp_cluster_schema.go
+++ b/akp/resource_akp_cluster_schema.go
@@ -81,22 +81,6 @@ func (r *AkpClusterResource) Schema(ctx context.Context, req resource.SchemaRequ
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"custom_image_registry_argoproj": schema.StringAttribute{
-				MarkdownDescription: "Custom Registry for Argoproj Images",
-				Optional:            true,
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"custom_image_registry_akuity": schema.StringAttribute{
-				MarkdownDescription: "Custom Registry for Akuity Images",
-				Optional:            true,
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"labels": schema.MapAttribute{
 				ElementType: types.StringType,
 				MarkdownDescription: "Cluster Labels",

--- a/akp/resource_akp_instance_schema.go
+++ b/akp/resource_akp_instance_schema.go
@@ -241,14 +241,6 @@ func (r *AkpInstanceResource) Schema(ctx context.Context, req resource.SchemaReq
 				MarkdownDescription: "Default Values For Cluster Agents",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
-					"custom_image_registry_argoproj": schema.StringAttribute{
-						MarkdownDescription: "Custom Image Registry for Argoproj images",
-						Optional:            true,
-					},
-					"custom_image_registry_akuity": schema.StringAttribute{
-						MarkdownDescription: "Custom Image Registry for Akuity images",
-						Optional:            true,
-					},
 					"auto_upgrade_disabled": schema.BoolAttribute{
 						MarkdownDescription: "Disable Agent Auto-upgrade",
 						Optional:            true,

--- a/akp/types/cluster.go
+++ b/akp/types/cluster.go
@@ -34,8 +34,6 @@ type AkpCluster struct {
 	NamespaceScoped             types.Bool   `tfsdk:"namespace_scoped"`
 	Size                        types.String `tfsdk:"size"`
 	AutoUpgradeDisabled         types.Bool   `tfsdk:"auto_upgrade_disabled"`
-	CustomImageRegistryArgoproj types.String `tfsdk:"custom_image_registry_argoproj"`
-	CustomImageRegistryAkuity   types.String `tfsdk:"custom_image_registry_akuity"`
 	Manifests                   types.String `tfsdk:"manifests"`
 	Labels                      types.Map    `tfsdk:"labels"`
 	Annotations                 types.Map    `tfsdk:"annotations"`
@@ -51,8 +49,6 @@ type AkpClusterKube struct {
 	NamespaceScoped             types.Bool   `tfsdk:"namespace_scoped"`
 	Size                        types.String `tfsdk:"size"`
 	AutoUpgradeDisabled         types.Bool   `tfsdk:"auto_upgrade_disabled"`
-	CustomImageRegistryArgoproj types.String `tfsdk:"custom_image_registry_argoproj"`
-	CustomImageRegistryAkuity   types.String `tfsdk:"custom_image_registry_akuity"`
 	Manifests                   types.String `tfsdk:"manifests"`
 	Labels                      types.Map    `tfsdk:"labels"`
 	Annotations                 types.Map    `tfsdk:"annotations"`
@@ -68,8 +64,6 @@ func (x *AkpClusterKube) Update(p *AkpCluster) error {
 	x.NamespaceScoped = p.NamespaceScoped
 	x.Size = p.Size
 	x.AutoUpgradeDisabled = p.AutoUpgradeDisabled
-	x.CustomImageRegistryArgoproj = p.CustomImageRegistryArgoproj
-	x.CustomImageRegistryAkuity = p.CustomImageRegistryAkuity
 	// x.Manifests = p.Manifests
 	x.Labels = p.Labels
 	x.Annotations = p.Annotations
@@ -103,8 +97,6 @@ func (x *AkpCluster) UpdateCluster(p *argocdv1.Cluster) diag.Diagnostics {
 	x.NamespaceScoped = types.BoolValue(p.GetNamespaceScoped())
 	x.Size = types.StringValue(ClusterSizeString[p.Data.Size])
 	x.AutoUpgradeDisabled = types.BoolValue(*p.Data.AutoUpgradeDisabled)
-	x.CustomImageRegistryArgoproj = types.StringValue(*p.Data.CustomImageRegistryArgoproj)
-	x.CustomImageRegistryAkuity = types.StringValue(*p.Data.CustomImageRegistryAkuity)
 	return diags
 }
 

--- a/akp/types/cluster_customization.go
+++ b/akp/types/cluster_customization.go
@@ -9,15 +9,11 @@ import (
 
 type AkpClusterCustomization struct {
 	AutoUpgradeDisabled    types.Bool   `tfsdk:"auto_upgrade_disabled"`
-	CustomRegistryArgoproj types.String `tfsdk:"custom_image_registry_argoproj"`
-	CustomRegistryAkuity   types.String `tfsdk:"custom_image_registry_akuity"`
 }
 
 var (
 	clusterCustomizationAttrTypes = map[string]attr.Type{
 		"auto_upgrade_disabled":          types.BoolType,
-		"custom_image_registry_argoproj": types.StringType,
-		"custom_image_registry_akuity":   types.StringType,
 	}
 )
 
@@ -33,21 +29,6 @@ func MergeClusterCustomization(state *AkpClusterCustomization, plan *AkpClusterC
 		res.AutoUpgradeDisabled = plan.AutoUpgradeDisabled
 	}
 
-	if plan.CustomRegistryAkuity.IsUnknown() {
-		res.CustomRegistryAkuity = state.CustomRegistryAkuity
-	} else if plan.CustomRegistryAkuity.IsNull() {
-		res.CustomRegistryAkuity = types.StringNull()
-	} else {
-		res.CustomRegistryAkuity = plan.CustomRegistryAkuity
-	}
-
-	if plan.CustomRegistryArgoproj.IsUnknown() {
-		res.CustomRegistryArgoproj = state.CustomRegistryArgoproj
-	} else if plan.CustomRegistryArgoproj.IsNull() {
-		res.CustomRegistryArgoproj = types.StringNull()
-	} else {
-		res.CustomRegistryArgoproj = plan.CustomRegistryArgoproj
-	}
 	return res, diags
 }
 
@@ -59,25 +40,11 @@ func (x *AkpClusterCustomization) UpdateObject(p *argocdv1.ClusterCustomization)
 	}
 	x.AutoUpgradeDisabled = types.BoolValue(p.GetAutoUpgradeDisabled())
 
-	if p.CustomImageRegistryAkuity == "" {
-		x.CustomRegistryAkuity = types.StringNull()
-	} else {
-		x.CustomRegistryAkuity = types.StringValue(p.CustomImageRegistryAkuity)
-	}
-
-	if p.CustomImageRegistryArgoproj == "" {
-		x.CustomRegistryArgoproj = types.StringNull()
-	} else {
-		x.CustomRegistryArgoproj = types.StringValue(p.CustomImageRegistryArgoproj)
-	}
-
 	return diags
 }
 
 func (x *AkpClusterCustomization) As(target *argocdv1.ClusterCustomization) diag.Diagnostics {
 	diags := diag.Diagnostics{}
-	target.CustomImageRegistryAkuity = x.CustomRegistryAkuity.ValueString()
-	target.CustomImageRegistryArgoproj = x.CustomRegistryArgoproj.ValueString()
 	target.AutoUpgradeDisabled = x.AutoUpgradeDisabled.ValueBool()
 	return diags
 }

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -36,8 +36,6 @@ data "akp_cluster" "example" {
 - `agent_version` (String) Installed agent version
 - `annotations` (Map of String) Cluster Annotations
 - `auto_upgrade_disabled` (Boolean) Disable Agents Auto Upgrade
-- `custom_image_registry_akuity` (String) Custom Registry for Akuity Images
-- `custom_image_registry_argoproj` (String) Custom Registry for Argoproj Images
 - `description` (String) Cluster Description
 - `id` (String) Cluster ID
 - `labels` (Map of String) Cluster Labels

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -42,8 +42,6 @@ Read-Only:
 - `agent_version` (String) Installed agent version
 - `annotations` (Map of String) Cluster Annotations
 - `auto_upgrade_disabled` (Boolean) Disable Agents Auto Upgrade
-- `custom_image_registry_akuity` (String) Custom Registry for Akuity Images
-- `custom_image_registry_argoproj` (String) Custom Registry for Argoproj Images
 - `description` (String) Cluster Description
 - `id` (String) Cluster ID
 - `instance_id` (String) Argo CD Instance ID

--- a/docs/data-sources/instance.md
+++ b/docs/data-sources/instance.md
@@ -88,8 +88,6 @@ Read-Only:
 Read-Only:
 
 - `auto_upgrade_disabled` (Boolean) Disable Agent Auto-upgrade
-- `custom_image_registry_akuity` (String) Custom Image Registry for Akuity images
-- `custom_image_registry_argoproj` (String) Custom Image Registry for Argoproj images
 
 
 <a id="nestedatt--extensions"></a>

--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -91,8 +91,6 @@ Read-Only:
 Read-Only:
 
 - `auto_upgrade_disabled` (Boolean) Disable Agent Auto-upgrade
-- `custom_image_registry_akuity` (String) Custom Image Registry for Akuity images
-- `custom_image_registry_argoproj` (String) Custom Image Registry for Argoproj images
 
 
 <a id="nestedatt--instances--extensions"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -45,8 +45,6 @@ resource "akp_cluster" "example" {
 
 - `annotations` (Map of String) Cluster Annotations
 - `auto_upgrade_disabled` (Boolean) Disable Agents Auto Upgrade. On resource update terraform will try to update the agent if this is set to `true`. Otherwise agent will update itself automatically
-- `custom_image_registry_akuity` (String) Custom Registry for Akuity Images
-- `custom_image_registry_argoproj` (String) Custom Registry for Argoproj Images
 - `description` (String) Cluster Description
 - `kube_config` (Attributes) Kubernetes connection setings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--kube_config))
 - `labels` (Map of String) Cluster Labels

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -125,8 +125,6 @@ Optional:
 Optional:
 
 - `auto_upgrade_disabled` (Boolean) Disable Agent Auto-upgrade
-- `custom_image_registry_akuity` (String) Custom Image Registry for Akuity images
-- `custom_image_registry_argoproj` (String) Custom Image Registry for Argoproj images
 
 
 <a id="nestedatt--extensions"></a>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/akuity/terraform-provider-akp
 go 1.19
 
 require (
-	github.com/akuity/api-client-go v0.3.0
+	github.com/akuity/api-client-go v0.4.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-go v0.14.3

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/akuity/api-client-go v0.3.0 h1:w1jq4FlCuCkbq+BD00Tt2+IOQqSZB2MIuIQ6ks5hctg=
 github.com/akuity/api-client-go v0.3.0/go.mod h1:r8hrBcOts2GLOZ928LQVNFQyf+0ZywPNd1QM87jxvXI=
+github.com/akuity/api-client-go v0.4.0 h1:CXo3z6+IHntHXPI392QcWh+e8HW8/AGVulvLerqvk7U=
+github.com/akuity/api-client-go v0.4.0/go.mod h1:r8hrBcOts2GLOZ928LQVNFQyf+0ZywPNd1QM87jxvXI=
 github.com/alevinval/sse v1.0.1 h1:cFubh2lMNdHT6niFLCsyTuhAgljaAWbdmceAe6qPIfo=
 github.com/alevinval/sse v1.0.1/go.mod h1:Bvl1EawUlmW1y1vSU5uDl03+1Zsqqz/+6D2PAUvftcw=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=


### PR DESCRIPTION
Due to change in API these fields are no longer supported.
The `kustomization` field will be implemented in the next versions of the provider.