### PR TITLE
docs: fix source namespace in upgrading guide

### DIFF
--- a/docs/guides/v0.5-upgrading.md
+++ b/docs/guides/v0.5-upgrading.md
@@ -18,7 +18,7 @@ For example, given this previous configuration:
 terraform {
   required_providers {
     akp = {
-      source  = "hashicorp/akp"
+      source  = "akuity/akp"
       version = "~> 0.4.0"
     }
   }
@@ -35,7 +35,7 @@ Update to the latest 0.5.x version:
 terraform {
   required_providers {
     akp = {
-      source  = "hashicorp/akp"
+      source  = "akuity/akp"
       version = "~> 0.5.0"
     }
   }


### PR DESCRIPTION
source namespace is akuity not hashicorp

Example of using `hashicorp/akp`:
```
% terraform init

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/akp versions matching "~> 0.5.0"...
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/akp:
│ provider registry registry.terraform.io does not have a provider named
│ registry.terraform.io/hashicorp/akp
│ 
│ All modules should specify their required_providers so that external consumers
│ will get the correct providers when using a module. To see which modules are
│ currently depending on hashicorp/akp, run the following command:
│     terraform providers
╵
```

Example of using `akuity/akp` (the fix):
```
% terraform init

Initializing the backend...

Initializing provider plugins...
- Finding akuity/akp versions matching "~> 0.5.0"...
- Installing akuity/akp v0.5.0...
- Installed akuity/akp v0.5.0 (self-signed, key ID C5FFEA4E6FF3A993)
```