### PR TITLE
chore: remove manifests from cluster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     concurrency:
       group: test
     strategy:
-      fail-fast: false
+      fail-fast: true
       max-parallel: 1
       matrix:
         # list whatever Terraform versions here you would like to support

--- a/akp/data_source_akp_cluster_schema.go
+++ b/akp/data_source_akp_cluster_schema.go
@@ -53,11 +53,6 @@ func getAKPClusterDataSourceAttributes() map[string]schema.Attribute {
 			Computed:            true,
 			Attributes:          getKubeconfigDataSourceAttributes(),
 		},
-		"manifests": schema.StringAttribute{
-			MarkdownDescription: "Agent installation manifests",
-			Computed:            true,
-			Sensitive:           true,
-		},
 		"remove_agent_resources_on_destroy": schema.BoolAttribute{
 			MarkdownDescription: "Remove agent Kubernetes resources from the managed cluster when destroying cluster",
 			Computed:            true,

--- a/akp/data_source_akp_cluster_test.go
+++ b/akp/data_source_akp_cluster_test.go
@@ -17,7 +17,7 @@ func TestAccClusterDataSource(t *testing.T) {
 			{
 				Config: providerConfig + testAccClusterDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.akp_cluster.test", "instance_id", "kgw15g3hg4ist8vl"),
+					resource.TestCheckResourceAttr("data.akp_cluster.test", "instance_id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "id", "t6swktevq53gtpu4"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "name", "data-source-cluster"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "namespace", "akuity"),
@@ -46,7 +46,7 @@ kind: Kustomization
 
 const testAccClusterDataSourceConfig = `
 data "akp_cluster" "test" {
-  instance_id = "kgw15g3hg4ist8vl"
+  instance_id = "6pzhawvy4echbd8x"
   name = "data-source-cluster"
 }
 `

--- a/akp/data_source_akp_cluster_test.go
+++ b/akp/data_source_akp_cluster_test.go
@@ -18,7 +18,7 @@ func TestAccClusterDataSource(t *testing.T) {
 				Config: providerConfig + testAccClusterDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "instance_id", "6pzhawvy4echbd8x"),
-					resource.TestCheckResourceAttr("data.akp_cluster.test", "id", "t6swktevq53gtpu4"),
+					resource.TestCheckResourceAttr("data.akp_cluster.test", "id", "nyc6s87mrlh4s2af"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "name", "data-source-cluster"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "namespace", "akuity"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "labels.test-label", "test"),
@@ -28,7 +28,7 @@ func TestAccClusterDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.namespace_scoped", "false"),
 					// spec.data
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.size", "small"),
-					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.auto_upgrade_disabled", "false"),
+					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.auto_upgrade_disabled", "true"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.kustomization", `apiVersion: kustomize.config.k8s.io/v1beta1
 images:
 - name: quay.io/akuityio/agent
@@ -36,7 +36,7 @@ images:
 kind: Kustomization
 `),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.app_replication", "false"),
-					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.target_version", "0.4.1"),
+					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.target_version", "0.4.3"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.redis_tunneling", "true"),
 				),
 			},

--- a/akp/data_source_akp_cluster_test.go
+++ b/akp/data_source_akp_cluster_test.go
@@ -23,7 +23,6 @@ func TestAccClusterDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "namespace", "akuity"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "labels.test-label", "test"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "annotations.test-annotation", "false"),
-					resource.TestCheckResourceAttrSet("data.akp_cluster.test", "manifests"),
 					// spec
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.description", "Cluster Description"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.namespace_scoped", "false"),

--- a/akp/data_source_akp_clusters.go
+++ b/akp/data_source_akp_clusters.go
@@ -76,7 +76,6 @@ func (d *AkpClustersDataSource) Read(ctx context.Context, req datasource.ReadReq
 			InstanceID: data.InstanceID,
 		}
 		stateCluster.Update(ctx, &resp.Diagnostics, cluster)
-		stateCluster.Manifests = getManifests(ctx, &resp.Diagnostics, d.akpCli.Cli, d.akpCli.OrgId, &stateCluster)
 		data.Clusters = append(data.Clusters, stateCluster)
 	}
 	// Save data into Terraform state

--- a/akp/data_source_akp_clusters_test.go
+++ b/akp/data_source_akp_clusters_test.go
@@ -17,11 +17,11 @@ func TestAccClustersDataSource(t *testing.T) {
 			{
 				Config: providerConfig + testAccClustersDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.akp_clusters.test", "instance_id", "kgw15g3hg4ist8vl"),
-					resource.TestCheckResourceAttr("data.akp_clusters.test", "id", "kgw15g3hg4ist8vl"),
+					resource.TestCheckResourceAttr("data.akp_clusters.test", "instance_id", "6pzhawvy4echbd8x"),
+					resource.TestCheckResourceAttr("data.akp_clusters.test", "id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.#", "1"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.id", "t6swktevq53gtpu4"),
-					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.instance_id", "kgw15g3hg4ist8vl"),
+					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.instance_id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.name", "data-source-cluster"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.namespace", "akuity"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.labels.test-label", "test"),
@@ -49,6 +49,6 @@ kind: Kustomization
 
 const testAccClustersDataSourceConfig = `
 data "akp_clusters" "test" {
-  instance_id = "kgw15g3hg4ist8vl"
+  instance_id = "6pzhawvy4echbd8x"
 }
 `

--- a/akp/data_source_akp_clusters_test.go
+++ b/akp/data_source_akp_clusters_test.go
@@ -20,7 +20,7 @@ func TestAccClustersDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "instance_id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.#", "1"),
-					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.id", "t6swktevq53gtpu4"),
+					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.id", "nyc6s87mrlh4s2af"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.instance_id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.name", "data-source-cluster"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.namespace", "akuity"),
@@ -31,7 +31,7 @@ func TestAccClustersDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.namespace_scoped", "false"),
 					// spec.data
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.size", "small"),
-					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.auto_upgrade_disabled", "false"),
+					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.auto_upgrade_disabled", "true"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.kustomization", `apiVersion: kustomize.config.k8s.io/v1beta1
 images:
 - name: quay.io/akuityio/agent
@@ -39,7 +39,7 @@ images:
 kind: Kustomization
 `),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.app_replication", "false"),
-					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.target_version", "0.4.1"),
+					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.target_version", "0.4.3"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.redis_tunneling", "true"),
 				),
 			},

--- a/akp/data_source_akp_clusters_test.go
+++ b/akp/data_source_akp_clusters_test.go
@@ -26,7 +26,6 @@ func TestAccClustersDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.namespace", "akuity"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.labels.test-label", "test"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.annotations.test-annotation", "false"),
-					resource.TestCheckResourceAttrSet("data.akp_clusters.test", "clusters.0.manifests"),
 					// spec
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.description", "Cluster Description"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.namespace_scoped", "false"),

--- a/akp/data_source_akp_instance_test.go
+++ b/akp/data_source_akp_instance_test.go
@@ -17,14 +17,14 @@ func TestAccInstanceDataSource(t *testing.T) {
 			{
 				Config: providerConfig + testAccInstanceDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.akp_instance.test", "id", "kgw15g3hg4ist8vl"),
+					resource.TestCheckResourceAttr("data.akp_instance.test", "id", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "name", "test-cluster"),
 
 					// argocd
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.description", "This is used by the terraform provider to test managing clusters."),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.version", "v2.7.9"),
 					// argocd.instance_spec
-					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.subdomain", "kgw15g3hg4ist8vl"),
+					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.subdomain", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.declarative_management_enabled", "false"),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.image_updater_enabled", "false"),
 

--- a/akp/data_source_akp_instance_test.go
+++ b/akp/data_source_akp_instance_test.go
@@ -22,14 +22,14 @@ func TestAccInstanceDataSource(t *testing.T) {
 
 					// argocd
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.description", "This is used by the terraform provider to test managing clusters."),
-					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.version", "v2.7.9"),
+					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.version", "v2.8.0"),
 					// argocd.instance_spec
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.subdomain", "6pzhawvy4echbd8x"),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.declarative_management_enabled", "false"),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.image_updater_enabled", "false"),
 
 					// argocd_cm
-					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd_cm.data.%", "3"),
+					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd_cm.data.%", "9"),
 				),
 			},
 		},

--- a/akp/resource_akp_cluster_schema.go
+++ b/akp/resource_akp_cluster_schema.go
@@ -80,11 +80,6 @@ func getAKPClusterAttributes() map[string]schema.Attribute {
 			Optional:            true,
 			Attributes:          getKubeconfigAttributes(),
 		},
-		"manifests": schema.StringAttribute{
-			MarkdownDescription: "Agent installation manifests",
-			Computed:            true,
-			Sensitive:           true,
-		},
 		"remove_agent_resources_on_destroy": schema.BoolAttribute{
 			MarkdownDescription: "Remove agent Kubernetes resources from the managed cluster when destroying cluster",
 			Optional:            true,

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -23,7 +23,6 @@ func TestAccClusterResource(t *testing.T) {
 					resource.TestCheckResourceAttr("akp_cluster.test", "namespace", "test"),
 					resource.TestCheckResourceAttr("akp_cluster.test", "labels.test-label", "true"),
 					resource.TestCheckResourceAttr("akp_cluster.test", "annotations.test-annotation", "false"),
-					resource.TestCheckResourceAttrSet("akp_cluster.test", "manifests"),
 					// spec
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.description", "test one"),
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.namespace_scoped", "true"),
@@ -47,7 +46,6 @@ func TestAccClusterResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.description", "test two"),
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.size", "medium"),
-					resource.TestCheckResourceAttrSet("akp_cluster.test", "manifests"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -56,7 +56,7 @@ func TestAccClusterResource(t *testing.T) {
 func testAccClusterResourceConfig(size string, description string) string {
 	return fmt.Sprintf(`
 resource "akp_cluster" "test" {
-  instance_id = "kgw15g3hg4ist8vl"
+  instance_id = "6pzhawvy4echbd8x"
   name      = "test"
   namespace = "test"
   labels = {

--- a/akp/types/cluster.go
+++ b/akp/types/cluster.go
@@ -19,7 +19,6 @@ type Cluster struct {
 	Annotations                   types.Map    `tfsdk:"annotations"`
 	Spec                          *ClusterSpec `tfsdk:"spec"`
 	Kubeconfig                    *Kubeconfig  `tfsdk:"kube_config"`
-	Manifests                     types.String `tfsdk:"manifests"`
 	RemoveAgentResourcesOnDestroy types.Bool   `tfsdk:"remove_agent_resources_on_destroy"`
 }
 

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -37,7 +37,6 @@ data "akp_cluster" "example" {
 - `id` (String) Cluster ID
 - `kube_config` (Attributes) Kubernetes connection settings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--kube_config))
 - `labels` (Map of String) Labels
-- `manifests` (String, Sensitive) Agent installation manifests
 - `namespace` (String) Agent installation namespace
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster
 - `spec` (Attributes) Cluster spec (see [below for nested schema](#nestedatt--spec))

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -48,7 +48,6 @@ Read-Only:
 - `id` (String) Cluster ID
 - `kube_config` (Attributes) Kubernetes connection settings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--clusters--kube_config))
 - `labels` (Map of String) Labels
-- `manifests` (String, Sensitive) Agent installation manifests
 - `namespace` (String) Agent installation namespace
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster
 - `spec` (Attributes) Cluster spec (see [below for nested schema](#nestedatt--clusters--spec))

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -80,7 +80,6 @@ resource "akp_cluster" "example" {
 ### Read-Only
 
 - `id` (String) Cluster ID
-- `manifests` (String, Sensitive) Agent installation manifests
 
 <a id="nestedatt--spec"></a>
 ### Nested Schema for `spec`


### PR DESCRIPTION
This PR removes `manifests` field since it is calculated from akuity platform, and it can not be known before apply.
This causes that it is always displayed as changed in the `terraform plan`.