### PR TITLE
fix(docs): link to akuity `argocd` image tags for version

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -215,7 +215,7 @@ Required:
 Required:
 
 - `instance_spec` (Attributes) Argo CD instance spec (see [below for nested schema](#nestedatt--argocd--spec--instance_spec))
-- `version` (String) Argo CD version. Should be equal to any [argo cd image tag](https://quay.io/repository/argoproj/argocd?tab=tags).
+- `version` (String) Argo CD version. Should be equal to any Akuity [`argocd` image tag](https://quay.io/repository/akuity/argocd?tab=tags).
 
 Optional:
 


### PR DESCRIPTION
Valid versions are any of the Akuity `argocd` image tags, not that of upstream.