### PR TITLE
chore: remove references to quay.io/akuityio/agent

### DIFF
--- a/akp/data_source_akp_cluster_test.go
+++ b/akp/data_source_akp_cluster_test.go
@@ -31,7 +31,7 @@ func TestAccClusterDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.auto_upgrade_disabled", "true"),
 					resource.TestCheckResourceAttr("data.akp_cluster.test", "spec.data.kustomization", `apiVersion: kustomize.config.k8s.io/v1beta1
 images:
-- name: quay.io/akuityio/agent
+- name: quay.io/akuity/agent
   newName: test.io/agent
 kind: Kustomization
 `),

--- a/akp/data_source_akp_clusters_test.go
+++ b/akp/data_source_akp_clusters_test.go
@@ -34,7 +34,7 @@ func TestAccClustersDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.auto_upgrade_disabled", "true"),
 					resource.TestCheckResourceAttr("data.akp_clusters.test", "clusters.0.spec.data.kustomization", `apiVersion: kustomize.config.k8s.io/v1beta1
 images:
-- name: quay.io/akuityio/agent
+- name: quay.io/akuity/agent
   newName: test.io/agent
 kind: Kustomization
 `),


### PR DESCRIPTION
Remove references to` quay.io/akuityio/agent`, we now use `quay.io/akuity/agent`