### PR TITLE
fix: do not commit erroneous state

### DIFF
--- a/akp/types/instance.go
+++ b/akp/types/instance.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"context"
-	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,12 +55,11 @@ func (i *Instance) GetSensitiveStrings(ctx context.Context, diagnostics *diag.Di
 	return res
 }
 
-func (i *Instance) Update(ctx context.Context, diagnostics *diag.Diagnostics, exportResp *argocdv1.ExportInstanceResponse) {
+func (i *Instance) Update(ctx context.Context, diagnostics *diag.Diagnostics, exportResp *argocdv1.ExportInstanceResponse) error {
 	var argoCD *v1alpha1.ArgoCD
 	err := marshal.RemarshalTo(exportResp.Argocd.AsMap(), &argoCD)
 	if err != nil {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get Argo CD instance. %s", err))
-		return
+		return errors.Wrap(err, "Unable to get Argo CD instance")
 	}
 	if i.ArgoCD == nil {
 		i.ArgoCD = &ArgoCD{}
@@ -74,4 +73,5 @@ func (i *Instance) Update(ctx context.Context, diagnostics *diag.Diagnostics, ex
 	i.ArgoCDTLSCertsConfigMap = ToConfigMapTFModel(ctx, diagnostics, exportResp.ArgocdTlsCertsConfigmap, i.ArgoCDTLSCertsConfigMap)
 	i.ArgoCDKnownHostsConfigMap = ToConfigMapTFModel(ctx, diagnostics, exportResp.ArgocdKnownHostsConfigmap, i.ArgoCDKnownHostsConfigMap)
 	i.ConfigManagementPlugins = ToConfigManagementPluginsTFModel(ctx, diagnostics, exportResp.ConfigManagementPlugins, i.ConfigManagementPlugins)
+	return nil
 }

--- a/dev.tfrc
+++ b/dev.tfrc
@@ -1,0 +1,19 @@
+# This is intended to facilitate local development, to use this locally run
+# ```
+# export TF_CLI_CONFIG_FILE=/wherever-terraform-provider-akp-is-located/dev.tfrc
+# ```
+
+provider_installation {
+  # Use /home/developer/terraform-provider-akp as an overridden package directory
+  # for the akuity/akp provider. This disables the version and checksum
+  # verifications for this provider and forces Terraform to look for the
+  # akp provider plugin in the given directory.
+  dev_overrides {
+    "akuity/akp" = "/home/developer/terraform-provider-akp"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}


### PR DESCRIPTION
In the case an AKP API error happens, it should not be committed into 
TF state.

If this fix looks good for the `akp_instance` resource, I can do the same
for all other resources.