### PR TITLE
fix: do not commit erroneous state in `akp_cluster`

### DIFF
--- a/akp/resource_akp_cluster.go
+++ b/akp/resource_akp_cluster.go
@@ -200,7 +200,7 @@ func (r *AkpClusterResource) applyInstance(ctx context.Context, plan *types.Clus
 	tflog.Debug(ctx, fmt.Sprintf("Apply cluster request: %s", apiReq))
 	_, err := applyInstance(ctx, apiReq)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to create Argo CD instance")
+		return nil, fmt.Errorf("unable to create Argo CD instance: %s", err)
 	}
 
 	if kubeconfig != nil {
@@ -209,7 +209,7 @@ func (r *AkpClusterResource) applyInstance(ctx context.Context, plan *types.Clus
 		if err != nil {
 			// Ensure kubeconfig won't be committed to state by setting it to nil
 			plan.Kubeconfig = nil
-			return plan, err
+			return plan, fmt.Errorf("unable to apply manifests: %s", err)
 		}
 	}
 

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -1,9 +1,13 @@
-//go:build !unit
-
 package akp
 
 import (
+	"context"
 	"fmt"
+	argocdv1 "github.com/akuity/api-client-go/pkg/api/gen/argocd/v1"
+	"github.com/akuity/terraform-provider-akp/akp/types"
+	hashitype "github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -117,4 +121,103 @@ EOF
   }
 }
 `, name, description, size)
+}
+
+func TestAkpClusterResource_applyInstance(t *testing.T) {
+	type args struct {
+		plan             *types.Cluster
+		apiReq           *argocdv1.ApplyInstanceRequest
+		isCreate         bool
+		applyInstance    func(context.Context, *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error)
+		upsertKubeConfig func(ctx context.Context, plan *types.Cluster, isCreate bool) error
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *types.Cluster
+		error error
+	}{
+		{
+			name: "happy path, no kubeconfig",
+			args: args{
+				plan: &types.Cluster{},
+				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
+					return &argocdv1.ApplyInstanceResponse{}, nil
+				},
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+					return errors.New("this should not be called")
+				},
+			},
+			want:  &types.Cluster{},
+			error: nil,
+		},
+		{
+			name: "error path, no kubeconfig",
+			args: args{
+				plan: &types.Cluster{},
+				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
+					return &argocdv1.ApplyInstanceResponse{}, errors.New("some error")
+				},
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+					return errors.New("this should not be called")
+				},
+			},
+			want:  nil,
+			error: fmt.Errorf("unable to create Argo CD instance: some error"),
+		},
+		{
+			name: "happy path, with kubeconfig",
+			args: args{
+				plan: &types.Cluster{
+					Kubeconfig: &types.Kubeconfig{
+						Host: hashitype.StringValue("some-host"),
+					},
+				},
+				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
+					return &argocdv1.ApplyInstanceResponse{}, nil
+				},
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+					assert.Equal(t, &types.Cluster{
+						Kubeconfig: &types.Kubeconfig{
+							Host: hashitype.StringValue("some-host"),
+						},
+					}, plan)
+					return nil
+				},
+			},
+			want: &types.Cluster{
+				Kubeconfig: &types.Kubeconfig{
+					Host: hashitype.StringValue("some-host"),
+				},
+			},
+			error: nil,
+		},
+		{
+			name: "error path, with kubeconfig",
+			args: args{
+				plan: &types.Cluster{
+					Kubeconfig: &types.Kubeconfig{
+						Host: hashitype.StringValue("some-host"),
+					},
+				},
+				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
+					return &argocdv1.ApplyInstanceResponse{}, nil
+				},
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+					return errors.New("some kube apply error")
+				},
+			},
+			want:  &types.Cluster{},
+			error: fmt.Errorf("unable to apply manifests: some kube apply error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &AkpClusterResource{}
+			ctx := context.Background()
+			got, err := r.applyInstance(ctx, tt.args.plan, tt.args.apiReq, tt.args.isCreate, tt.args.applyInstance, tt.args.upsertKubeConfig)
+			assert.Equal(t, tt.error, err)
+			assert.Equalf(t, tt.want, got, "applyInstance(%v, %v, %v)", tt.args.plan, tt.args.apiReq, tt.args.isCreate)
+		})
+	}
 }


### PR DESCRIPTION
In the case an AKP API error happens, this should not be committed into TF state. This is a bit more involved than for `akp_instance` since it is e.g. possible for a cluster to be created in AKP, but the manifests for whatever reason may not be created (when applicable).