### PR TITLE
fix: only set bool value when known

### DIFF
--- a/akp/resource_akp_kargo.go
+++ b/akp/resource_akp_kargo.go
@@ -235,6 +235,7 @@ func refreshKargoState(ctx context.Context, diagnostics *diag.Diagnostics, clien
 	exportReq := &kargov1.ExportKargoInstanceRequest{
 		OrganizationId: orgID,
 		Id:             kargo.ID.ValueString(),
+		WorkspaceId:    resp.Instance.WorkspaceId,
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Export Kargo instance request: %s", exportReq))
 	exportResp, err := client.ExportKargoInstance(ctx, exportReq)

--- a/akp/types/kargo_types.go
+++ b/akp/types/kargo_types.go
@@ -95,7 +95,7 @@ func (k *Kargo) ToKargoAPIModel(ctx context.Context, diag *diag.Diagnostics, nam
 			Description: k.Spec.Description.ValueString(),
 			Version:     k.Spec.Version.ValueString(),
 			KargoInstanceSpec: v1alpha1.KargoInstanceSpec{
-				BackendIpAllowListEnabled:  k.Spec.KargoInstanceSpec.BackendIpAllowListEnabled.ValueBoolPointer(),
+				BackendIpAllowListEnabled:  toBoolPointer(k.Spec.KargoInstanceSpec.BackendIpAllowListEnabled),
 				IpAllowList:                toKargoIpAllowListAPIModel(k.Spec.KargoInstanceSpec.IpAllowList),
 				AgentCustomizationDefaults: toKargoAgentCustomizationAPIModel(k.Spec.KargoInstanceSpec.AgentCustomizationDefaults, diag),
 				DefaultShardAgent:          k.Spec.KargoInstanceSpec.DefaultShardAgent.ValueString(),
@@ -139,7 +139,7 @@ func toKargoAgentCustomizationAPIModel(agentCustomizationDefaults *KargoAgentCus
 		}
 	}
 	return &v1alpha1.KargoAgentCustomization{
-		AutoUpgradeDisabled: agentCustomizationDefaults.AutoUpgradeDisabled.ValueBoolPointer(),
+		AutoUpgradeDisabled: toBoolPointer(agentCustomizationDefaults.AutoUpgradeDisabled),
 		Kustomization:       raw,
 	}
 }
@@ -307,7 +307,7 @@ func toKargoAgentDataAPIModel(ctx context.Context, diagnostics *diag.Diagnostics
 
 	return v1alpha1.KargoAgentData{
 		Size:                v1alpha1.KargoAgentSize(data.Size.ValueString()),
-		AutoUpgradeDisabled: data.AutoUpgradeDisabled.ValueBoolPointer(),
+		AutoUpgradeDisabled: toBoolPointer(data.AutoUpgradeDisabled),
 		TargetVersion:       data.TargetVersion.ValueString(),
 		Kustomization:       raw,
 		RemoteArgocd:        data.RemoteArgocd.ValueString(),
@@ -325,8 +325,8 @@ func toKargoOidcConfigAPIModel(ctx context.Context, diag *diag.Diagnostics, oidc
 		additionalScopes = append(additionalScopes, scope.ValueString())
 	}
 	return &v1alpha1.KargoOidcConfig{
-		Enabled:          oidcConfig.Enabled.ValueBoolPointer(),
-		DexEnabled:       oidcConfig.DexEnabled.ValueBoolPointer(),
+		Enabled:          toBoolPointer(oidcConfig.Enabled),
+		DexEnabled:       toBoolPointer(oidcConfig.DexEnabled),
 		DexConfig:        oidcConfig.DexConfig.ValueString(),
 		DexConfigSecret:  toKargoDexConfigSecretAPIModel(ctx, oidcConfig.DexConfigSecret),
 		IssuerURL:        oidcConfig.IssuerURL.ValueString(),

--- a/akp/types/types.go
+++ b/akp/types/types.go
@@ -121,26 +121,33 @@ func (a *ArgoCD) ToArgoCDAPIModel(ctx context.Context, diag *diag.Diagnostics, n
 			InstanceSpec: v1alpha1.InstanceSpec{
 				IpAllowList:                     toIPAllowListAPIModel(a.Spec.InstanceSpec.IpAllowList),
 				Subdomain:                       a.Spec.InstanceSpec.Subdomain.ValueString(),
-				DeclarativeManagementEnabled:    a.Spec.InstanceSpec.DeclarativeManagementEnabled.ValueBoolPointer(),
+				DeclarativeManagementEnabled:    toBoolPointer(a.Spec.InstanceSpec.DeclarativeManagementEnabled),
 				Extensions:                      toExtensionsAPIModel(a.Spec.InstanceSpec.Extensions),
 				ClusterCustomizationDefaults:    toClusterCustomizationAPIModel(ctx, diag, a.Spec.InstanceSpec.ClusterCustomizationDefaults),
-				ImageUpdaterEnabled:             a.Spec.InstanceSpec.ImageUpdaterEnabled.ValueBoolPointer(),
-				BackendIpAllowListEnabled:       a.Spec.InstanceSpec.BackendIpAllowListEnabled.ValueBoolPointer(),
+				ImageUpdaterEnabled:             toBoolPointer(a.Spec.InstanceSpec.ImageUpdaterEnabled),
+				BackendIpAllowListEnabled:       toBoolPointer(a.Spec.InstanceSpec.BackendIpAllowListEnabled),
 				RepoServerDelegate:              toRepoServerDelegateAPIModel(a.Spec.InstanceSpec.RepoServerDelegate),
-				AuditExtensionEnabled:           a.Spec.InstanceSpec.AuditExtensionEnabled.ValueBoolPointer(),
-				SyncHistoryExtensionEnabled:     a.Spec.InstanceSpec.SyncHistoryExtensionEnabled.ValueBoolPointer(),
+				AuditExtensionEnabled:           toBoolPointer(a.Spec.InstanceSpec.AuditExtensionEnabled),
+				SyncHistoryExtensionEnabled:     toBoolPointer(a.Spec.InstanceSpec.SyncHistoryExtensionEnabled),
 				CrossplaneExtension:             toCrossplaneExtensionAPIModel(a.Spec.InstanceSpec.CrossplaneExtension),
 				ImageUpdaterDelegate:            toImageUpdaterDelegateAPIModel(a.Spec.InstanceSpec.ImageUpdaterDelegate),
 				AppSetDelegate:                  toAppSetDelegateAPIModel(a.Spec.InstanceSpec.AppSetDelegate),
-				AssistantExtensionEnabled:       a.Spec.InstanceSpec.AssistantExtensionEnabled.ValueBoolPointer(),
+				AssistantExtensionEnabled:       toBoolPointer(a.Spec.InstanceSpec.AssistantExtensionEnabled),
 				AppsetPolicy:                    toAppsetPolicyAPIModel(ctx, diag, a.Spec.InstanceSpec.AppsetPolicy),
 				HostAliases:                     toHostAliasesAPIModel(a.Spec.InstanceSpec.HostAliases),
 				AgentPermissionsRules:           toAgentPermissionsRuleAPIModel(a.Spec.InstanceSpec.AgentPermissionsRules),
 				Fqdn:                            a.Spec.InstanceSpec.Fqdn.ValueStringPointer(),
-				MultiClusterK8SDashboardEnabled: a.Spec.InstanceSpec.MultiClusterK8SDashboardEnabled.ValueBoolPointer(),
+				MultiClusterK8SDashboardEnabled: toBoolPointer(a.Spec.InstanceSpec.MultiClusterK8SDashboardEnabled),
 			},
 		},
 	}
+}
+
+func toBoolPointer(b tftypes.Bool) *bool {
+	if b.IsUnknown() {
+		return nil
+	}
+	return b.ValueBoolPointer()
 }
 
 func (c *Cluster) Update(ctx context.Context, diagnostics *diag.Diagnostics, apiCluster *argocdv1.Cluster, plan *Cluster) {
@@ -457,15 +464,15 @@ func toClusterDataAPIModel(ctx context.Context, diagnostics *diag.Diagnostics, c
 	}
 	return v1alpha1.ClusterData{
 		Size:                            v1alpha1.ClusterSize(size),
-		AutoUpgradeDisabled:             clusterData.AutoUpgradeDisabled.ValueBoolPointer(),
+		AutoUpgradeDisabled:             toBoolPointer(clusterData.AutoUpgradeDisabled),
 		Kustomization:                   raw,
-		AppReplication:                  clusterData.AppReplication.ValueBoolPointer(),
+		AppReplication:                  toBoolPointer(clusterData.AppReplication),
 		TargetVersion:                   clusterData.TargetVersion.ValueString(),
-		RedisTunneling:                  clusterData.RedisTunneling.ValueBoolPointer(),
-		DatadogAnnotationsEnabled:       clusterData.DatadogAnnotationsEnabled.ValueBoolPointer(),
-		EksAddonEnabled:                 clusterData.EksAddonEnabled.ValueBoolPointer(),
+		RedisTunneling:                  toBoolPointer(clusterData.RedisTunneling),
+		DatadogAnnotationsEnabled:       toBoolPointer(clusterData.DatadogAnnotationsEnabled),
+		EksAddonEnabled:                 toBoolPointer(clusterData.EksAddonEnabled),
 		ManagedClusterConfig:            managedConfig,
-		MultiClusterK8SDashboardEnabled: clusterData.MultiClusterK8SDashboardEnabled.ValueBoolPointer(),
+		MultiClusterK8SDashboardEnabled: toBoolPointer(clusterData.MultiClusterK8SDashboardEnabled),
 		AutoscalerConfig:                autoscalerConfigAPI,
 	}
 }
@@ -475,7 +482,7 @@ func toRepoServerDelegateAPIModel(repoServerDelegate *RepoServerDelegate) *v1alp
 		return nil
 	}
 	return &v1alpha1.RepoServerDelegate{
-		ControlPlane:   repoServerDelegate.ControlPlane.ValueBoolPointer(),
+		ControlPlane:   toBoolPointer(repoServerDelegate.ControlPlane),
 		ManagedCluster: toManagedClusterAPIModel(repoServerDelegate.ManagedCluster),
 	}
 }
@@ -510,7 +517,7 @@ func toImageUpdaterDelegateAPIModel(imageUpdaterDelegate *ImageUpdaterDelegate) 
 		return nil
 	}
 	return &v1alpha1.ImageUpdaterDelegate{
-		ControlPlane:   imageUpdaterDelegate.ControlPlane.ValueBoolPointer(),
+		ControlPlane:   toBoolPointer(imageUpdaterDelegate.ControlPlane),
 		ManagedCluster: toManagedClusterAPIModel(imageUpdaterDelegate.ManagedCluster),
 	}
 }
@@ -547,10 +554,10 @@ func toClusterCustomizationAPIModel(ctx context.Context, diagnostics *diag.Diagn
 		diagnostics.AddError("failed unmarshal kustomization string to yaml", err.Error())
 	}
 	return &v1alpha1.ClusterCustomization{
-		AutoUpgradeDisabled: customization.AutoUpgradeDisabled.ValueBoolPointer(),
+		AutoUpgradeDisabled: toBoolPointer(customization.AutoUpgradeDisabled),
 		Kustomization:       raw,
-		AppReplication:      customization.AppReplication.ValueBoolPointer(),
-		RedisTunneling:      customization.RedisTunneling.ValueBoolPointer(),
+		AppReplication:      toBoolPointer(customization.AppReplication),
+		RedisTunneling:      toBoolPointer(customization.RedisTunneling),
 	}
 }
 
@@ -597,7 +604,7 @@ func toAppsetPolicyAPIModel(ctx context.Context, diagnostics *diag.Diagnostics, 
 	}
 	return &v1alpha1.AppsetPolicy{
 		Policy:         policy.Policy.ValueString(),
-		OverridePolicy: policy.OverridePolicy.ValueBoolPointer(),
+		OverridePolicy: toBoolPointer(policy.OverridePolicy),
 	}
 }
 


### PR DESCRIPTION
This PR fixes two issues:
1. currently bool values are set to false if the value is unknown. This leads to a problem where default features that have been turned on during creation may be updated to off.
1. kargo instances may not be found due to the lack of workspace ID.