### PR TITLE
fix: enable account.admin to surpass admin.enabled

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -151,6 +151,8 @@ resource "akp_instance" "example" {
     # When configuring the `argocd_cm`, make sure to specify the following keys (from "admin.enabled", to "users.anonymous.enabled") since those keys are added by Akuity Platform by default.
     # If they are not defined, you may see inconsistent results and errors from the provider.
     # Feel free to customize the values based on your usage, but the keys themselves must be specified.
+    # Note that "admin.enabled" cannot be set to true independently, and an "accounts.admin" key is required, like the "accounts.alice" key below, once you add that, remove the "admin.enabled" key.
+    # "admin.enabled"                  = false
     "accounts.admin"                 = "apiKey,login"
     "exec.enabled"                   = true
     "ga.anonymizeusers"              = false

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -151,8 +151,7 @@ resource "akp_instance" "example" {
     # When configuring the `argocd_cm`, make sure to specify the following keys (from "admin.enabled", to "users.anonymous.enabled") since those keys are added by Akuity Platform by default.
     # If they are not defined, you may see inconsistent results and errors from the provider.
     # Feel free to customize the values based on your usage, but the keys themselves must be specified.
-    # Note that "admin.enabled" cannot be set to true independently, and an "accounts.admin" key is required, like the "accounts.alice" key below, once you add that, remove the "admin.enabled" key.
-    "admin.enabled"                  = false
+    "accounts.admin"                 = "apiKey,login"
     "exec.enabled"                   = true
     "ga.anonymizeusers"              = false
     "helm.enabled"                   = true


### PR DESCRIPTION
For #143 

Currently, there is no way `admin.enabled` supports this tf-provider-akp unless it is false and removed. So I have removed this field and added `account.admin` to support that.

![image](https://github.com/user-attachments/assets/4142d5e5-a457-4bc0-bd14-5c97b0bea62d)

cc @blakepettersson 