### PR TITLE
fix: filter cm fields not already present in resource

### DIFF
--- a/akp/types/configmap.go
+++ b/akp/types/configmap.go
@@ -20,7 +20,7 @@ func ToFilteredConfigMapTFModel(ctx context.Context, diagnostics *diag.Diagnosti
 		}
 	}
 
-	oldMap := make(map[string]interface{})
+	oldMap := make(map[string]interface{}, len(oldCM.Elements()))
 	for k, v := range oldCM.Elements() {
 		oldMap[k] = v
 	}
@@ -30,8 +30,8 @@ func ToFilteredConfigMapTFModel(ctx context.Context, diagnostics *diag.Diagnosti
 	// Only include values which are a part of the original resource map. The reason for doing so is that the API returns
 	// a lot of fields which can cause TF to have an inconsistent state. We rely on the backend being able to do the right
 	// thing in regard to PATCH requests; we don't actually need to have all the fields which the API returns in the state.
-	for k, v := range oldMap {
-		if _, ok := m[k]; ok {
+	for k := range oldMap {
+		if v, ok := m[k]; ok {
 			switch t := v.(type) {
 			case string:
 				sortedValue, err := sortJSONString(t)

--- a/akp/types/configmap.go
+++ b/akp/types/configmap.go
@@ -13,6 +13,44 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func ToFilteredConfigMapTFModel(ctx context.Context, diagnostics *diag.Diagnostics, data *structpb.Struct, oldCM tftypes.Map) tftypes.Map {
+	if data == nil || len(data.AsMap()) == 0 {
+		if !oldCM.IsUnknown() && (oldCM.IsNull() || len(oldCM.Elements()) == 0) {
+			return oldCM
+		}
+	}
+
+	oldMap := make(map[string]interface{})
+	for k, v := range oldCM.Elements() {
+		oldMap[k] = v
+	}
+
+	m := data.AsMap()
+
+	// Only include values which are a part of the original resource map. The reason for doing so is that the API returns
+	// a lot of fields which can cause TF to have an inconsistent state. We rely on the backend being able to do the right
+	// thing in regard to PATCH requests; we don't actually need to have all the fields which the API returns in the state.
+	for k, v := range oldMap {
+		if _, ok := m[k]; ok {
+			switch t := v.(type) {
+			case string:
+				sortedValue, err := sortJSONString(t)
+				if err != nil {
+					diagnostics.AddError("Client Error", fmt.Sprintf("Unable to sort JSON keys for key %s. %s", k, err))
+					return tftypes.MapNull(tftypes.StringType)
+				}
+				oldMap[k] = sortedValue
+			default:
+				oldMap[k] = v
+			}
+		}
+	}
+
+	newData, diag := tftypes.MapValueFrom(ctx, tftypes.StringType, &oldMap)
+	diagnostics.Append(diag...)
+	return newData
+}
+
 func ToConfigMapTFModel(ctx context.Context, diagnostics *diag.Diagnostics, data *structpb.Struct, oldCM tftypes.Map) tftypes.Map {
 	if data == nil || len(data.AsMap()) == 0 {
 		if !oldCM.IsUnknown() && (oldCM.IsNull() || len(oldCM.Elements()) == 0) {

--- a/akp/types/instance.go
+++ b/akp/types/instance.go
@@ -70,7 +70,7 @@ func (i *Instance) Update(ctx context.Context, diagnostics *diag.Diagnostics, ex
 		argoCD.Spec.InstanceSpec.Fqdn = &fqdn
 	}
 	i.ArgoCD.Update(ctx, diagnostics, argoCD)
-	i.ArgoCDConfigMap = ToConfigMapTFModel(ctx, diagnostics, exportResp.ArgocdConfigmap, i.ArgoCDConfigMap)
+	i.ArgoCDConfigMap = ToFilteredConfigMapTFModel(ctx, diagnostics, exportResp.ArgocdConfigmap, i.ArgoCDConfigMap)
 	i.ArgoCDRBACConfigMap = ToConfigMapTFModel(ctx, diagnostics, exportResp.ArgocdRbacConfigmap, i.ArgoCDRBACConfigMap)
 	i.NotificationsConfigMap = ToConfigMapTFModel(ctx, diagnostics, exportResp.NotificationsConfigmap, i.NotificationsConfigMap)
 	i.ImageUpdaterConfigMap = ToConfigMapTFModel(ctx, diagnostics, exportResp.ImageUpdaterConfigmap, i.ImageUpdaterConfigMap)

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -148,8 +148,12 @@ resource "akp_instance" "example" {
     }
   }
   argocd_cm = {
-    # When configuring `argocd_cm`, there is generally no need to need to set all of these keys. If you do not set a key, the API will set suitable default values.
-    # Please note that the API will disallow the setting of certain keys (such as "admin.enabled", or any key which isn't a known configuration option in `argocd-cm`).
+    # When configuring `argocd_cm`, there is generally no need to set all of these keys. If you do not set a key, the API will set suitable default values.
+    # Please note that the API will disallow the setting of  any key which isn't a known configuration option in `argocd-cm`.
+    #
+    # NOTE:
+    # `admin.enabled` can be set to `false` to disable the admin login.
+    # To enable the admin account, set `accounts.admin: "login"`, and to disable the admin login, set `admin.enabled: false`. They are mutually exclusive.
     "exec.enabled"                   = true
     "ga.anonymizeusers"              = false
     "helm.enabled"                   = true

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -148,11 +148,8 @@ resource "akp_instance" "example" {
     }
   }
   argocd_cm = {
-    # When configuring the `argocd_cm`, make sure to specify the following keys (from "admin.enabled", to "users.anonymous.enabled") since those keys are added by Akuity Platform by default.
-    # If they are not defined, you may see inconsistent results and errors from the provider.
-    # Feel free to customize the values based on your usage, but the keys themselves must be specified.
-    # Note that "admin.enabled" cannot be set to true independently, and an "accounts.admin" key is required, like the "accounts.alice" key below, once you add that, remove the "admin.enabled" key.
-    "admin.enabled"                  = false
+    # When configuring `argocd_cm`, there is generally no need to need to set all of these keys. If you do not set a key, the API will set suitable default values.
+    # Please note that the API will disallow the setting of certain keys (such as "admin.enabled", or any key which isn't a known configuration option in `argocd-cm`).
     "exec.enabled"                   = true
     "ga.anonymizeusers"              = false
     "helm.enabled"                   = true

--- a/examples/resources/akp_instance/resource.tf
+++ b/examples/resources/akp_instance/resource.tf
@@ -46,11 +46,8 @@ resource "akp_instance" "example" {
     }
   }
   argocd_cm = {
-    # When configuring the `argocd_cm`, make sure to specify the following keys (from "admin.enabled", to "users.anonymous.enabled") since those keys are added by Akuity Platform by default.
-    # If they are not defined, you may see inconsistent results and errors from the provider.
-    # Feel free to customize the values based on your usage, but the keys themselves must be specified.
-    # Note that "admin.enabled" cannot be set to true independently, and an "accounts.admin" key is required, like the "accounts.alice" key below, once you add that, remove the "admin.enabled" key.
-    "admin.enabled"                  = false
+    # When configuring `argocd_cm`, there is generally no need to need to set all of these keys. If you do not set a key, the API will set suitable default values.
+    # Please note that the API will disallow the setting of certain keys (such as "admin.enabled", or any key which isn't a known configuration option in `argocd-cm`).
     "exec.enabled"                   = true
     "ga.anonymizeusers"              = false
     "helm.enabled"                   = true

--- a/examples/resources/akp_instance/resource.tf
+++ b/examples/resources/akp_instance/resource.tf
@@ -46,8 +46,12 @@ resource "akp_instance" "example" {
     }
   }
   argocd_cm = {
-    # When configuring `argocd_cm`, there is generally no need to need to set all of these keys. If you do not set a key, the API will set suitable default values.
-    # Please note that the API will disallow the setting of certain keys (such as "admin.enabled", or any key which isn't a known configuration option in `argocd-cm`).
+    # When configuring `argocd_cm`, there is generally no need to set all of these keys. If you do not set a key, the API will set suitable default values.
+    # Please note that the API will disallow the setting of  any key which isn't a known configuration option in `argocd-cm`.
+    #
+    # NOTE:
+    # `admin.enabled` can be set to `false` to disable the admin login.
+    # To enable the admin account, set `accounts.admin: "login"`, and to disable the admin login, set `admin.enabled: false`. They are mutually exclusive.
     "exec.enabled"                   = true
     "ga.anonymizeusers"              = false
     "helm.enabled"                   = true


### PR DESCRIPTION
This would fix a lot of the inconsistent state issues which we see, where if we don't specify the exact keys that the API returns, the provider fails horribly. This also simplifies the config from a user perspective, since they don't have to specify every single key that the API returns. This means that from a TF perspective, the config becomes minimal in most cases.

This relies on the fact that when we submit requests to the ApplyConfig endpoint, that only the cm fields specified are set; any other field that needs to be present in the data model relies on the API to set the correct defaults.

Fixes #143