### PR TITLE
feat: set workspace as part of the provider config

### DIFF
--- a/akp/provider.go
+++ b/akp/provider.go
@@ -12,6 +12,7 @@ import (
 	orgcv1 "github.com/akuity/api-client-go/pkg/api/gen/organization/v1"
 	idv1 "github.com/akuity/api-client-go/pkg/api/gen/types/id/v1"
 	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
+	"github.com/pkg/errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -34,14 +35,16 @@ type AkpProviderModel struct {
 	ApiKeySecret     types.String `tfsdk:"api_key_secret"`
 	OrganizationName types.String `tfsdk:"org_name"`
 	SkipTLSVerify    types.Bool   `tfsdk:"skip_tls_verify"`
+	WorkspaceName    types.String `tfsdk:"workspace_name"`
 }
 
 type AkpCli struct {
-	Cli      argocdv1.ArgoCDServiceGatewayClient
-	KargoCli kargov1.KargoServiceGatewayClient
-	Cred     accesscontrol.ClientCredential
-	OrgCli   orgcv1.OrganizationServiceGatewayClient
-	OrgId    string
+	Cli       argocdv1.ArgoCDServiceGatewayClient
+	KargoCli  kargov1.KargoServiceGatewayClient
+	Cred      accesscontrol.ClientCredential
+	OrgCli    orgcv1.OrganizationServiceGatewayClient
+	OrgId     string
+	Workspace *orgcv1.Workspace
 }
 
 func (p *AkpProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -74,6 +77,10 @@ func (p *AkpProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 				Optional:            true,
 				Sensitive:           true,
 			},
+			"workspace_name": schema.StringAttribute{
+				MarkdownDescription: "Name of the Workspace to use. Default value is the default workspace.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -105,6 +112,8 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if ServerUrl == "" {
 		ServerUrl = "https://akuity.cloud"
 	}
+	workspace := config.WorkspaceName.ValueString()
+
 	if apiKeyID == "" {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("api_key_id"),
@@ -130,6 +139,7 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	ctx = tflog.SetField(ctx, "skip_tls_verify", skipTLSVerify)
 	ctx = tflog.SetField(ctx, "api_key_id", apiKeyID)
 	ctx = tflog.SetField(ctx, "org_name", orgName)
+	ctx = tflog.SetField(ctx, "workspace", workspace)
 
 	tflog.Debug(ctx, "Getting Organization ID by name")
 
@@ -159,12 +169,23 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	argoc := argocdv1.NewArgoCDServiceGatewayClient(gwc)
 	kargoc := kargov1.NewKargoServiceGatewayClient(gwc)
 	orgc = orgcv1.NewOrganizationServiceGatewayClient(gwc)
+	ws, err := getWorkspace(ctx, orgc, orgID, workspace)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Unable to get Workspace %s", workspace),
+			fmt.Sprintf("An unexpected error occurred when fetching the %s workspace.\n", workspace)+
+				"Akuity Platform Client Error: "+err.Error(),
+		)
+		return
+	}
+
 	akpCli := &AkpCli{
-		Cli:      argoc,
-		KargoCli: kargoc,
-		Cred:     cred,
-		OrgId:    orgID,
-		OrgCli:   orgc,
+		Cli:       argoc,
+		KargoCli:  kargoc,
+		Cred:      cred,
+		OrgId:     orgID,
+		OrgCli:    orgc,
+		Workspace: ws,
 	}
 	resp.DataSourceData = akpCli
 	resp.ResourceData = akpCli
@@ -196,4 +217,24 @@ func New(version string) func() provider.Provider {
 			version: version,
 		}
 	}
+}
+
+func getWorkspace(ctx context.Context, orgc orgcv1.OrganizationServiceGatewayClient, orgid, name string) (*orgcv1.Workspace, error) {
+	workspaces, err := orgc.ListWorkspaces(ctx, &orgcv1.ListWorkspacesRequest{
+		OrganizationId: orgid,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to read org workspaces")
+	}
+	for _, w := range workspaces.GetWorkspaces() {
+		if name == "" && w.IsDefault {
+			// if no workspace name is provided, return the default workspace
+			return w, nil
+		}
+		if w.Name == name {
+			return w, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Workspace %s not found", name)
 }

--- a/akp/resource_akp_kargoagent.go
+++ b/akp/resource_akp_kargoagent.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	kargov1 "github.com/akuity/api-client-go/pkg/api/gen/kargo/v1"
-	orgcv1 "github.com/akuity/api-client-go/pkg/api/gen/organization/v1"
 	healthv1 "github.com/akuity/api-client-go/pkg/api/gen/types/status/health/v1"
 	reconv1 "github.com/akuity/api-client-go/pkg/api/gen/types/status/reconciliation/v1"
 	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
@@ -179,23 +178,8 @@ func (r *AkpKargoAgentResource) ImportState(ctx context.Context, req resource.Im
 
 func (r *AkpKargoAgentResource) upsert(ctx context.Context, diagnostics *diag.Diagnostics, plan *types.KargoAgent, isCreate bool) (*types.KargoAgent, error) {
 	ctx = httpctx.SetAuthorizationHeader(ctx, r.akpCli.Cred.Scheme(), r.akpCli.Cred.Credential())
-	workspaces, err := r.akpCli.OrgCli.ListWorkspaces(ctx, &orgcv1.ListWorkspacesRequest{
-		OrganizationId: r.akpCli.OrgId,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to read workspaces")
-	}
-	var workspaceId string
-	for _, w := range workspaces.GetWorkspaces() {
-		if w.GetIsDefault() {
-			workspaceId = w.GetId()
-			break
-		}
-	}
-	if workspaceId == "" {
-		return nil, errors.New("Default workspace not found")
-	}
-	apiReq := buildKargoAgentApplyRequest(ctx, diagnostics, plan, r.akpCli.OrgId, workspaceId)
+
+	apiReq := buildKargoAgentApplyRequest(ctx, diagnostics, plan, r.akpCli.OrgId, r.akpCli.Workspace.Id)
 	if diagnostics.HasError() {
 		return nil, nil
 	}


### PR DESCRIPTION
Setting workspace as part of the provider config allows aliasing providers to manage multiple workspaces.

Default value when no workspace is specified is to return the workspace where `IsDefault=true`