### PR TITLE
feat: add workspace config to kargo instance and kargo agent

### DIFF
--- a/akp/data_source_akp_instance_test.go
+++ b/akp/data_source_akp_instance_test.go
@@ -35,8 +35,8 @@ func TestAccInstanceDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.host_aliases.0.hostnames.0", "test-1"),
 					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd.spec.instance_spec.host_aliases.0.hostnames.1", "test-2"),
 
-					// argocd_cm
-					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd_cm.%", "9"),
+					// argocd_cm, all fields should be computed.
+					resource.TestCheckResourceAttr("data.akp_instance.test", "argocd_cm.%", "0"),
 				),
 			},
 		},

--- a/akp/data_source_akp_kargo_schema.go
+++ b/akp/data_source_akp_kargo_schema.go
@@ -40,6 +40,10 @@ func getAKPKargoDataSourceAttributes() map[string]schema.Attribute {
 			ElementType:         types.StringType,
 			Computed:            true,
 		},
+		"workspace": schema.StringAttribute{
+			MarkdownDescription: "Workspace name for the Kargo instance",
+			Computed:            true,
+		},
 	}
 }
 

--- a/akp/data_source_akp_kargoagent_schema.go
+++ b/akp/data_source_akp_kargoagent_schema.go
@@ -25,6 +25,10 @@ func getAKPKargoAgentDataSourceAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "The ID of the Kargo instance",
 			Required:            true,
 		},
+		"workspace": schema.StringAttribute{
+			MarkdownDescription: "Workspace name for the Kargo agent",
+			Computed:            true,
+		},
 		"name": schema.StringAttribute{
 			MarkdownDescription: "The name of the Kargo agent",
 			Required:            true,

--- a/akp/provider.go
+++ b/akp/provider.go
@@ -12,6 +12,7 @@ import (
 	orgcv1 "github.com/akuity/api-client-go/pkg/api/gen/organization/v1"
 	idv1 "github.com/akuity/api-client-go/pkg/api/gen/types/id/v1"
 	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
+	"github.com/pkg/errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -34,14 +35,16 @@ type AkpProviderModel struct {
 	ApiKeySecret     types.String `tfsdk:"api_key_secret"`
 	OrganizationName types.String `tfsdk:"org_name"`
 	SkipTLSVerify    types.Bool   `tfsdk:"skip_tls_verify"`
+	WorkspaceName    types.String `tfsdk:"workspace_name"`
 }
 
 type AkpCli struct {
-	Cli      argocdv1.ArgoCDServiceGatewayClient
-	KargoCli kargov1.KargoServiceGatewayClient
-	Cred     accesscontrol.ClientCredential
-	OrgCli   orgcv1.OrganizationServiceGatewayClient
-	OrgId    string
+	Cli       argocdv1.ArgoCDServiceGatewayClient
+	KargoCli  kargov1.KargoServiceGatewayClient
+	Cred      accesscontrol.ClientCredential
+	OrgCli    orgcv1.OrganizationServiceGatewayClient
+	OrgId     string
+	Workspace *orgcv1.Workspace
 }
 
 func (p *AkpProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -74,6 +77,10 @@ func (p *AkpProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 				Optional:            true,
 				Sensitive:           true,
 			},
+			"workspace_name": schema.StringAttribute{
+				MarkdownDescription: "Name of the Workspace to use. Default value is the default workspace.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -105,6 +112,8 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if ServerUrl == "" {
 		ServerUrl = "https://akuity.cloud"
 	}
+	workspace := config.WorkspaceName.ValueString()
+
 	if apiKeyID == "" {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("api_key_id"),
@@ -130,6 +139,7 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	ctx = tflog.SetField(ctx, "skip_tls_verify", skipTLSVerify)
 	ctx = tflog.SetField(ctx, "api_key_id", apiKeyID)
 	ctx = tflog.SetField(ctx, "org_name", orgName)
+	ctx = tflog.SetField(ctx, "workspace", workspace)
 
 	tflog.Debug(ctx, "Getting Organization ID by name")
 
@@ -159,12 +169,23 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	argoc := argocdv1.NewArgoCDServiceGatewayClient(gwc)
 	kargoc := kargov1.NewKargoServiceGatewayClient(gwc)
 	orgc = orgcv1.NewOrganizationServiceGatewayClient(gwc)
+	ws, err := getWorkspace(ctx, orgc, orgID, workspace)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Unable to get Workspace %s", workspace),
+			fmt.Sprintf("An unexpected error occurred when fetching the %s workspace.\n", workspace)+
+				"Akuity Platform Client Error: "+err.Error(),
+		)
+		return
+	}
+
 	akpCli := &AkpCli{
-		Cli:      argoc,
-		KargoCli: kargoc,
-		Cred:     cred,
-		OrgId:    orgID,
-		OrgCli:   orgc,
+		Cli:       argoc,
+		KargoCli:  kargoc,
+		Cred:      cred,
+		OrgId:     orgID,
+		OrgCli:    orgc,
+		Workspace: ws,
 	}
 	resp.DataSourceData = akpCli
 	resp.ResourceData = akpCli
@@ -196,4 +217,24 @@ func New(version string) func() provider.Provider {
 			version: version,
 		}
 	}
+}
+
+func getWorkspace(ctx context.Context, orgc orgcv1.OrganizationServiceGatewayClient, orgid, name string) (*orgcv1.Workspace, error) {
+	workspaces, err := orgc.ListWorkspaces(ctx, &orgcv1.ListWorkspacesRequest{
+		OrganizationId: orgid,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to read org workspaces")
+	}
+	for _, w := range workspaces.GetWorkspaces() {
+		if name == "" && w.IsDefault {
+			// if no workspace name is provided, return the default workspace
+			return w, nil
+		}
+		if w.Name == name {
+			return w, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Workspace %s not found", name)
 }

--- a/akp/resource_akp_kargo.go
+++ b/akp/resource_akp_kargo.go
@@ -156,6 +156,9 @@ func (r *AkpKargoInstanceResource) upsert(ctx context.Context, diagnostics *diag
 		return errors.Wrap(err, "Unable to upsert Kargo instance")
 	}
 
+	if plan.Workspace.ValueString() == "" {
+		plan.Workspace = tftypes.StringValue(workspace.GetName())
+	}
 	return refreshKargoState(ctx, diagnostics, r.akpCli.KargoCli, plan, r.akpCli.OrgId)
 }
 

--- a/akp/resource_akp_kargo_schema.go
+++ b/akp/resource_akp_kargo_schema.go
@@ -59,6 +59,14 @@ func getAKPKargoInstanceAttributes() map[string]schema.Attribute {
 			Optional:            true,
 			Sensitive:           true,
 		},
+		"workspace": schema.StringAttribute{
+			Optional:            true,
+			Computed:            true,
+			MarkdownDescription: "Workspace name for the Kargo instance",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
 	}
 }
 

--- a/akp/resource_akp_kargoagent.go
+++ b/akp/resource_akp_kargoagent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	tftypes "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slices"
@@ -191,6 +192,10 @@ func (r *AkpKargoAgentResource) upsert(ctx context.Context, diagnostics *diag.Di
 	result, err := r.applyKargoInstance(ctx, plan, apiReq, isCreate, r.akpCli.KargoCli.ApplyKargoInstance, r.upsertKubeConfig)
 	if err != nil {
 		return result, err
+	}
+
+	if plan.Workspace.ValueString() == "" {
+		plan.Workspace = tftypes.StringValue(workspace.GetName())
 	}
 	return result, refreshKargoAgentState(ctx, diagnostics, r.akpCli.KargoCli, result, r.akpCli.OrgId, nil, plan)
 }

--- a/akp/resource_akp_kargoagent.go
+++ b/akp/resource_akp_kargoagent.go
@@ -179,7 +179,12 @@ func (r *AkpKargoAgentResource) ImportState(ctx context.Context, req resource.Im
 func (r *AkpKargoAgentResource) upsert(ctx context.Context, diagnostics *diag.Diagnostics, plan *types.KargoAgent, isCreate bool) (*types.KargoAgent, error) {
 	ctx = httpctx.SetAuthorizationHeader(ctx, r.akpCli.Cred.Scheme(), r.akpCli.Cred.Credential())
 
-	apiReq := buildKargoAgentApplyRequest(ctx, diagnostics, plan, r.akpCli.OrgId, r.akpCli.Workspace.Id)
+	workspace, err := getWorkspace(ctx, r.akpCli.OrgCli, r.akpCli.OrgId, plan.Workspace.ValueString())
+	if err != nil {
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get workspace. %s", err))
+		return nil, errors.New("Unable to get workspace")
+	}
+	apiReq := buildKargoAgentApplyRequest(ctx, diagnostics, plan, r.akpCli.OrgId, workspace.Id)
 	if diagnostics.HasError() {
 		return nil, nil
 	}

--- a/akp/resource_akp_kargoagent.go
+++ b/akp/resource_akp_kargoagent.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	kargov1 "github.com/akuity/api-client-go/pkg/api/gen/kargo/v1"
-	orgcv1 "github.com/akuity/api-client-go/pkg/api/gen/organization/v1"
 	healthv1 "github.com/akuity/api-client-go/pkg/api/gen/types/status/health/v1"
 	reconv1 "github.com/akuity/api-client-go/pkg/api/gen/types/status/reconciliation/v1"
 	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
@@ -179,23 +178,8 @@ func (r *AkpKargoAgentResource) ImportState(ctx context.Context, req resource.Im
 
 func (r *AkpKargoAgentResource) upsert(ctx context.Context, diagnostics *diag.Diagnostics, plan *types.KargoAgent, isCreate bool) (*types.KargoAgent, error) {
 	ctx = httpctx.SetAuthorizationHeader(ctx, r.akpCli.Cred.Scheme(), r.akpCli.Cred.Credential())
-	workspaces, err := r.akpCli.OrgCli.ListWorkspaces(ctx, &orgcv1.ListWorkspacesRequest{
-		OrganizationId: r.akpCli.OrgId,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to read workspaces")
-	}
-	var workspaceId string
-	for _, w := range workspaces.GetWorkspaces() {
-		if w.GetIsDefault() {
-			workspaceId = w.GetId()
-			break
-		}
-	}
-	if workspaceId == "" {
-		return nil, errors.New("Default workspace not found")
-	}
-	apiReq := buildKargoAgentApplyRequest(ctx, diagnostics, plan, r.akpCli.OrgId, workspaceId)
+
+	apiReq := buildKargoAgentApplyRequest(ctx, diagnostics, plan, r.akpCli.OrgId, r.akpCli.Workspace.Id)
 	if diagnostics.HasError() {
 		return nil, nil
 	}

--- a/akp/resource_akp_kargoagent_schema.go
+++ b/akp/resource_akp_kargoagent_schema.go
@@ -38,6 +38,14 @@ func getAKPKargoAgentResourceAttributes() map[string]schema.Attribute {
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
+		"workspace": schema.StringAttribute{
+			Optional:            true,
+			Computed:            true,
+			MarkdownDescription: "Workspace name for the Kargo agent",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
 		"name": schema.StringAttribute{
 			MarkdownDescription: "The name of the Kargo agent",
 			Required:            true,
@@ -150,7 +158,8 @@ func getAKPKargoAgentDataAttributes() map[string]schema.Attribute {
 			Optional:            true,
 			Computed:            true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifier.RequiresReplaceIfConfigured(),
 			},
 		},
 		"akuity_managed": schema.BoolAttribute{
@@ -158,7 +167,8 @@ func getAKPKargoAgentDataAttributes() map[string]schema.Attribute {
 			Optional:            true,
 			Computed:            true,
 			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.RequiresReplace(),
+				boolplanmodifier.UseStateForUnknown(),
+				boolplanmodifier.RequiresReplaceIfConfigured(),
 			},
 		},
 		"argocd_namespace": schema.StringAttribute{

--- a/akp/types/kargo_instance.go
+++ b/akp/types/kargo_instance.go
@@ -20,6 +20,7 @@ type KargoInstance struct {
 	Kargo          *Kargo       `tfsdk:"kargo"`
 	KargoConfigMap types.Map    `tfsdk:"kargo_cm"`
 	KargoSecret    types.Map    `tfsdk:"kargo_secret"`
+	Workspace      types.String `tfsdk:"workspace"`
 }
 
 func (k *KargoInstance) Update(ctx context.Context, diagnostics *diag.Diagnostics, exportResp *kargov1.ExportKargoInstanceResponse) error {

--- a/akp/types/kargoagent.go
+++ b/akp/types/kargoagent.go
@@ -12,6 +12,7 @@ import (
 type KargoAgent struct {
 	ID                            types.String    `tfsdk:"id"`
 	InstanceID                    types.String    `tfsdk:"instance_id"`
+	Workspace                     types.String    `tfsdk:"workspace"`
 	Name                          types.String    `tfsdk:"name"`
 	Namespace                     types.String    `tfsdk:"namespace"`
 	Labels                        types.Map       `tfsdk:"labels"`

--- a/docs/data-sources/kargo_agent.md
+++ b/docs/data-sources/kargo_agent.md
@@ -35,6 +35,7 @@ data "akp_kargo_agent" "example" {
 - `namespace` (String) The namespace of the Kargo agent
 - `remove_agent_resources_on_destroy` (Boolean) Whether to remove agent resources on destroy
 - `spec` (Attributes) The spec of the Kargo agent (see [below for nested schema](#nestedatt--spec))
+- `workspace` (String) Workspace name for the Kargo agent
 
 <a id="nestedatt--kube_config"></a>
 ### Nested Schema for `kube_config`

--- a/docs/data-sources/kargo_agents.md
+++ b/docs/data-sources/kargo_agents.md
@@ -51,6 +51,7 @@ Read-Only:
 - `namespace` (String) The namespace of the Kargo agent
 - `remove_agent_resources_on_destroy` (Boolean) Whether to remove agent resources on destroy
 - `spec` (Attributes) The spec of the Kargo agent (see [below for nested schema](#nestedatt--agents--spec))
+- `workspace` (String) Workspace name for the Kargo agent
 
 <a id="nestedatt--agents--kube_config"></a>
 ### Nested Schema for `agents.kube_config`

--- a/docs/data-sources/kargo_instance.md
+++ b/docs/data-sources/kargo_instance.md
@@ -31,6 +31,7 @@ data "akp_kargo_instance" "example" {
 - `kargo` (Attributes) Specification of the Kargo instance (see [below for nested schema](#nestedatt--kargo))
 - `kargo_cm` (Map of String) ConfigMap to configure system account accesses. The usage can be found in the examples/resources/akp_kargo_instance/resource.tf
 - `kargo_secret` (Map of String) Secret to configure system account accesses. The usage can be found in the examples/resources/akp_kargo_instance/resource.tf
+- `workspace` (String) Workspace name for the Kargo instance
 
 <a id="nestedatt--kargo"></a>
 ### Nested Schema for `kargo`

--- a/docs/resources/kargo_agent.md
+++ b/docs/resources/kargo_agent.md
@@ -29,6 +29,7 @@ resource "akp_kargo_agent" "example-agent" {
   instance_id = akp_kargo_instance.example.id
   name        = "test-agent"
   namespace   = "test-namespace"
+  workspace   = "kargo-workspace"
   labels = {
     "app" = "kargo"
   }
@@ -54,6 +55,7 @@ resource "akp_kargo_agent" "example-agent" {
   instance_id = akp_kargo_instance.example.id
   name        = "test-agent"
   namespace   = "test-namespace"
+  workspace   = "kargo-workspace"
   labels = {
     "app" = "kargo"
   }
@@ -105,6 +107,7 @@ EOT
 - `labels` (Map of String) Labels
 - `namespace` (String) The namespace of the Kargo agent
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster, default to `true`
+- `workspace` (String) Workspace name for the Kargo agent
 
 ### Read-Only
 

--- a/docs/resources/kargo_instance.md
+++ b/docs/resources/kargo_instance.md
@@ -26,7 +26,8 @@ resource "akp_kargo_instance" "example" {
 ## Example Usage (Exhaustive)
 ```terraform
 resource "akp_kargo_instance" "example" {
-  name = "test"
+  name      = "test"
+  workspace = "kargo-workspace"
   kargo_cm = {
     adminAccountEnabled  = "true"
     adminAccountTokenTtl = "24h"
@@ -128,6 +129,7 @@ EOT
 
 - `kargo_cm` (Map of String) ConfigMap to configure system account accesses. The usage can be found in the examples/resources/akp_kargo_instance/resource.tf
 - `kargo_secret` (Map of String, Sensitive) Secret to configure system account accesses. The usage can be found in the examples/resources/akp_kargo_instance/resource.tf
+- `workspace` (String) Workspace name for the Kargo instance
 
 ### Read-Only
 

--- a/examples/resources/akp_kargo_agent/akuity_managed.tf
+++ b/examples/resources/akp_kargo_agent/akuity_managed.tf
@@ -2,6 +2,7 @@ resource "akp_kargo_agent" "example-agent" {
   instance_id = akp_kargo_instance.example.id
   name        = "test-agent"
   namespace   = "test-namespace"
+  workspace   = "kargo-workspace"
   labels = {
     "app" = "kargo"
   }

--- a/examples/resources/akp_kargo_agent/self_hosted.tf
+++ b/examples/resources/akp_kargo_agent/self_hosted.tf
@@ -2,6 +2,7 @@ resource "akp_kargo_agent" "example-agent" {
   instance_id = akp_kargo_instance.example.id
   name        = "test-agent"
   namespace   = "test-namespace"
+  workspace   = "kargo-workspace"
   labels = {
     "app" = "kargo"
   }

--- a/examples/resources/akp_kargo_instance/resource.tf
+++ b/examples/resources/akp_kargo_instance/resource.tf
@@ -1,5 +1,6 @@
 resource "akp_kargo_instance" "example" {
   name = "test"
+  workspace = "kargo-workspace"
   kargo_cm = {
     adminAccountEnabled  = "true"
     adminAccountTokenTtl = "24h"

--- a/examples/resources/akp_kargo_instance/resource.tf
+++ b/examples/resources/akp_kargo_instance/resource.tf
@@ -1,5 +1,5 @@
 resource "akp_kargo_instance" "example" {
-  name = "test"
+  name      = "test"
   workspace = "kargo-workspace"
   kargo_cm = {
     adminAccountEnabled  = "true"


### PR DESCRIPTION
This implements improvements based on the commits in https://github.com/akuity/terraform-provider-akp/pull/323, enabling more fine-grained workspace config for the resources. Otherwise, different resources in the terraform file would need to be in the same workspace to function properly.