### PR TITLE
feat: add exec plugin support

### DIFF
--- a/akp/resource_akp_cluster.go
+++ b/akp/resource_akp_cluster.go
@@ -136,7 +136,7 @@ func (r *AkpClusterResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	ctx = httpctx.SetAuthorizationHeader(ctx, r.akpCli.Cred.Scheme(), r.akpCli.Cred.Credential())
-	kubeconfig, err := getKubeconfig(plan.Kubeconfig)
+	kubeconfig, err := getKubeconfig(ctx, plan.Kubeconfig)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", err.Error())
 		return
@@ -221,7 +221,7 @@ func (r *AkpClusterResource) applyInstance(ctx context.Context, plan *types.Clus
 
 func (r *AkpClusterResource) upsertKubeConfig(ctx context.Context, plan *types.Cluster, isCreate bool) error {
 	// Apply agent manifests to clusters if the kubeconfig is specified for cluster.
-	kubeconfig, err := getKubeconfig(plan.Kubeconfig)
+	kubeconfig, err := getKubeconfig(ctx, plan.Kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -287,11 +287,11 @@ func buildClusters(ctx context.Context, diagnostics *diag.Diagnostics, cluster *
 	return cs
 }
 
-func getKubeconfig(kubeConfig *types.Kubeconfig) (*rest.Config, error) {
+func getKubeconfig(ctx context.Context, kubeConfig *types.Kubeconfig) (*rest.Config, error) {
 	if kubeConfig == nil {
 		return nil, nil
 	}
-	kcfg, err := kube.InitializeConfiguration(kubeConfig)
+	kcfg, err := kube.InitializeConfiguration(ctx, kubeConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot initialize Kubectl. Please check kubernetes configuration")
 	}

--- a/akp/resource_akp_kargoagent.go
+++ b/akp/resource_akp_kargoagent.go
@@ -129,7 +129,7 @@ func (r *AkpKargoAgentResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	ctx = httpctx.SetAuthorizationHeader(ctx, r.akpCli.Cred.Scheme(), r.akpCli.Cred.Credential())
-	kubeconfig, err := getKubeconfig(plan.Kubeconfig)
+	kubeconfig, err := getKubeconfig(ctx, plan.Kubeconfig)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", err.Error())
 		return
@@ -224,7 +224,7 @@ func (r *AkpKargoAgentResource) applyKargoInstance(ctx context.Context, plan *ty
 
 func (r *AkpKargoAgentResource) upsertKubeConfig(ctx context.Context, plan *types.KargoAgent, isCreate bool) error {
 	// Apply agent manifests to clusters if the kubeconfig is specified for cluster.
-	kubeconfig, err := getKubeconfig(plan.Kubeconfig)
+	kubeconfig, err := getKubeconfig(ctx, plan.Kubeconfig)
 	if err != nil {
 		return err
 	}

--- a/akp/types/kubeconfig.go
+++ b/akp/types/kubeconfig.go
@@ -17,4 +17,12 @@ type Kubeconfig struct {
 	ConfigContextCluster  types.String `tfsdk:"config_context_cluster"`
 	Token                 types.String `tfsdk:"token"`
 	ProxyUrl              types.String `tfsdk:"proxy_url"`
+	Exec                  *Exec        `tfsdk:"exec"`
+}
+
+type Exec struct {
+	APIVersion types.String `tfsdk:"api_version"`
+	Command    types.String `tfsdk:"command"`
+	Args       types.List   `tfsdk:"args"`
+	Env        types.Map    `tfsdk:"env"`
 }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -48,6 +48,9 @@ resource "akp_cluster" "my-cluster" {
       api_version = "client.authentication.k8s.io/v1"
       args        = ["eks", "get-token", "--cluster-name", "some-cluster"]
       command     = "aws"
+      env = {
+        AWS_REGION = "us-west-2"
+      }
     }
   }
   name      = "my-cluster"

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -36,6 +36,30 @@ resource "akp_cluster" "my-cluster" {
 
 For a complete working example using a GKE cluster, see [akuity/examples](https://github.com/akuity/examples/tree/main/terraform/akuity).
 
+## Example Usage (using a k8s exec plugin)
+```terraform
+resource "akp_cluster" "my-cluster" {
+  instance_id = akp_instance.argocd.id
+  kube_config = {
+    host                   = "https://${cluster.my-cluster.endpoint}"
+    cluster_ca_certificate = "${base64decode(cluster.my-cluster.master_auth.0.cluster_ca_certificate)}"
+    // No need to hardcode a token!
+    exec = {
+      api_version = "client.authentication.k8s.io/v1"
+      args        = ["eks", "get-token", "--cluster-name", "some-cluster"]
+      command     = "aws"
+    }
+  }
+  name      = "my-cluster"
+  namespace = "akuity"
+  spec = {
+    data = {
+      size = "small"
+    }
+  }
+}
+```
+
 ## Example Usage (Custom agent size)
 ```terraform
 data "akp_instance" "example" {
@@ -377,12 +401,26 @@ Optional:
 - `config_context_cluster` (String)
 - `config_path` (String) Path to the kube config file.
 - `config_paths` (List of String) A list of paths to kube config files.
+- `exec` (Attributes) Configuration for the Kubernetes client authentication exec‐plugin (see [below for nested schema](#nestedatt--kube_config--exec))
 - `host` (String) The hostname (in form of URI) of Kubernetes master.
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
 - `token` (String, Sensitive) Token to authenticate an service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
+
+<a id="nestedatt--kube_config--exec"></a>
+### Nested Schema for `kube_config.exec`
+
+Required:
+
+- `api_version` (String)
+- `command` (String) The exec plugin binary to call
+
+Optional:
+
+- `args` (List of String) Arguments to pass to the exec plugin
+- `env` (Map of String) Environment variables for the exec plugin
 
 ## Import
 

--- a/docs/resources/kargo_agent.md
+++ b/docs/resources/kargo_agent.md
@@ -155,12 +155,26 @@ Optional:
 - `config_context_cluster` (String)
 - `config_path` (String) Path to the kube config file.
 - `config_paths` (List of String) A list of paths to kube config files.
+- `exec` (Attributes) Configuration for the Kubernetes client authentication exec‐plugin (see [below for nested schema](#nestedatt--kube_config--exec))
 - `host` (String) The hostname (in form of URI) of Kubernetes master.
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
 - `token` (String, Sensitive) Token to authenticate an service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
+
+<a id="nestedatt--kube_config--exec"></a>
+### Nested Schema for `kube_config.exec`
+
+Required:
+
+- `api_version` (String)
+- `command` (String) The exec plugin binary to call
+
+Optional:
+
+- `args` (List of String) Arguments to pass to the exec plugin
+- `env` (Map of String) Environment variables for the exec plugin
 
 ## Import
 

--- a/examples/resources/akp_cluster/exec.tf
+++ b/examples/resources/akp_cluster/exec.tf
@@ -1,0 +1,20 @@
+resource "akp_cluster" "my-cluster" {
+  instance_id = akp_instance.argocd.id
+  kube_config = {
+    host                   = "https://${cluster.my-cluster.endpoint}"
+    cluster_ca_certificate = "${base64decode(cluster.my-cluster.master_auth.0.cluster_ca_certificate)}"
+    // No need to hardcode a token!
+    exec = {
+      api_version = "client.authentication.k8s.io/v1"
+      args        = ["eks", "get-token", "--cluster-name", "some-cluster"]
+      command     = "aws"
+    }
+  }
+  name      = "my-cluster"
+  namespace = "akuity"
+  spec = {
+    data = {
+      size = "small"
+    }
+  }
+}

--- a/examples/resources/akp_cluster/exec.tf
+++ b/examples/resources/akp_cluster/exec.tf
@@ -8,6 +8,9 @@ resource "akp_cluster" "my-cluster" {
       api_version = "client.authentication.k8s.io/v1"
       args        = ["eks", "get-token", "--cluster-name", "some-cluster"]
       command     = "aws"
+      env = {
+        AWS_REGION = "us-west-2"
+      }
     }
   }
   name      = "my-cluster"

--- a/templates/resources/cluster.md.tmpl
+++ b/templates/resources/cluster.md.tmpl
@@ -19,6 +19,9 @@ description: |-
 
 For a complete working example using a GKE cluster, see [akuity/examples](https://github.com/akuity/examples/tree/main/terraform/akuity).
 
+## Example Usage (using a k8s exec plugin)
+{{ tffile "./examples/resources/akp_cluster/exec.tf" }}
+
 ## Example Usage (Custom agent size)
 {{ tffile "./examples/resources/akp_cluster/custom_agent_size.tf" }}
 


### PR DESCRIPTION
This adds the ability to use exec plugins directly from the provider rather than needing to rely on other providers to generate temporary tokens. Fixes #310.