### PR TITLE
fix: add reapply_manifest_on_update option to apply manifests when updating agent

### DIFF
--- a/akp/data_source_akp_cluster_schema.go
+++ b/akp/data_source_akp_cluster_schema.go
@@ -57,6 +57,10 @@ func getAKPClusterDataSourceAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Remove agent Kubernetes resources from the managed cluster when destroying cluster",
 			Computed:            true,
 		},
+		"reapply_manifests_on_update": schema.BoolAttribute{
+			MarkdownDescription: "Whether to reapply manifests on update",
+			Computed:            true,
+		},
 	}
 }
 

--- a/akp/data_source_akp_kargoagent_schema.go
+++ b/akp/data_source_akp_kargoagent_schema.go
@@ -61,6 +61,10 @@ func getAKPKargoAgentDataSourceAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Whether to remove agent resources on destroy",
 			Computed:            true,
 		},
+		"reapply_manifests_on_update": schema.BoolAttribute{
+			MarkdownDescription: "Whether to reapply manifests on update",
+			Computed:            true,
+		},
 	}
 }
 

--- a/akp/resource_akp_cluster_schema.go
+++ b/akp/resource_akp_cluster_schema.go
@@ -111,6 +111,14 @@ func getAKPClusterAttributes() map[string]schema.Attribute {
 			Computed:            true,
 			Default:             booldefault.StaticBool(true),
 		},
+		"reapply_manifests_on_update": schema.BoolAttribute{
+			MarkdownDescription: "If true, re-apply generated Argo CD agent manifests to the target cluster on every update when `kube_config` is provided.",
+			Optional:            true,
+			Computed:            true,
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
 	}
 }
 

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -130,7 +130,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 		apiReq           *argocdv1.ApplyInstanceRequest
 		isCreate         bool
 		applyInstance    func(context.Context, *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error)
-		upsertKubeConfig func(ctx context.Context, plan *types.Cluster, isCreate bool) error
+		upsertKubeConfig func(ctx context.Context, plan *types.Cluster) error
 	}
 	tests := []struct {
 		name  string
@@ -145,7 +145,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, nil
 				},
-				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
 					return errors.New("this should not be called")
 				},
 			},
@@ -159,7 +159,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, errors.New("some error")
 				},
-				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
 					return errors.New("this should not be called")
 				},
 			},
@@ -177,7 +177,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, nil
 				},
-				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
 					assert.Equal(t, &types.Cluster{
 						Kubeconfig: &types.Kubeconfig{
 							Host: hashitype.StringValue("some-host"),
@@ -204,7 +204,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, nil
 				},
-				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster, isCreate bool) error {
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
 					return errors.New("some kube apply error")
 				},
 			},

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -141,7 +141,8 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 		{
 			name: "happy path, no kubeconfig",
 			args: args{
-				plan: &types.Cluster{},
+				plan:     &types.Cluster{},
+				isCreate: true,
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, nil
 				},
@@ -155,7 +156,8 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 		{
 			name: "error path, no kubeconfig",
 			args: args{
-				plan: &types.Cluster{},
+				plan:     &types.Cluster{},
+				isCreate: true,
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, errors.New("some error")
 				},
@@ -177,6 +179,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, nil
 				},
+				isCreate: true,
 				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
 					assert.Equal(t, &types.Cluster{
 						Kubeconfig: &types.Kubeconfig{
@@ -201,6 +204,7 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 						Host: hashitype.StringValue("some-host"),
 					},
 				},
+				isCreate: true,
 				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
 					return &argocdv1.ApplyInstanceResponse{}, nil
 				},
@@ -219,6 +223,49 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 			got, err := r.applyInstance(ctx, tt.args.plan, tt.args.apiReq, tt.args.isCreate, tt.args.applyInstance, tt.args.upsertKubeConfig)
 			assert.Equal(t, tt.error, err)
 			assert.Equalf(t, tt.want, got, "applyInstance(%v, %v, %v)", tt.args.plan, tt.args.apiReq, tt.args.isCreate)
+		})
+	}
+}
+
+func TestAkpClusterResource_reApplyManifests(t *testing.T) {
+	type args struct {
+		plan             *types.Cluster
+		apiReq           *argocdv1.ApplyInstanceRequest
+		applyInstance    func(context.Context, *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error)
+		upsertKubeConfig func(ctx context.Context, plan *types.Cluster) error
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *types.Cluster
+		error error
+	}{
+		{
+			name: "error path, with kubeconfig",
+			args: args{
+				plan: &types.Cluster{
+					Kubeconfig: &types.Kubeconfig{
+						Host: hashitype.StringValue("some-host"),
+					},
+					ReapplyManifestsOnUpdate: hashitype.BoolValue(true),
+				},
+				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
+					return &argocdv1.ApplyInstanceResponse{}, nil
+				},
+				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
+					return errors.New("some kube apply error")
+				},
+			},
+			want:  &types.Cluster{},
+			error: fmt.Errorf("unable to apply manifests: some kube apply error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &AkpClusterResource{}
+			ctx := context.Background()
+			_, err := r.applyInstance(ctx, tt.args.plan, tt.args.apiReq, false, tt.args.applyInstance, tt.args.upsertKubeConfig)
+			assert.Equal(t, tt.error, err)
 		})
 	}
 }

--- a/akp/resource_akp_kargoagent_schema.go
+++ b/akp/resource_akp_kargoagent_schema.go
@@ -99,6 +99,14 @@ func getAKPKargoAgentResourceAttributes() map[string]schema.Attribute {
 			Computed:            true,
 			Default:             booldefault.StaticBool(true),
 		},
+		"reapply_manifests_on_update": schema.BoolAttribute{
+			MarkdownDescription: "If true, re-apply generated agent manifests to the target cluster on every update when `kube_config` is provided.",
+			Optional:            true,
+			Computed:            true,
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
 	}
 }
 

--- a/akp/types/cluster.go
+++ b/akp/types/cluster.go
@@ -20,6 +20,7 @@ type Cluster struct {
 	Spec                          *ClusterSpec `tfsdk:"spec"`
 	Kubeconfig                    *Kubeconfig  `tfsdk:"kube_config"`
 	RemoveAgentResourcesOnDestroy types.Bool   `tfsdk:"remove_agent_resources_on_destroy"`
+	ReapplyManifestsOnUpdate      types.Bool   `tfsdk:"reapply_manifests_on_update"`
 }
 
 type Clusters struct {

--- a/akp/types/kargo_types.go
+++ b/akp/types/kargo_types.go
@@ -200,6 +200,11 @@ func (ka *KargoAgent) Update(ctx context.Context, diagnostics *diag.Diagnostics,
 	if ka.RemoveAgentResourcesOnDestroy.IsUnknown() || ka.RemoveAgentResourcesOnDestroy.IsNull() {
 		ka.RemoveAgentResourcesOnDestroy = tftypes.BoolValue(true)
 	}
+	if ka.ReapplyManifestsOnUpdate.IsUnknown() || ka.ReapplyManifestsOnUpdate.IsNull() {
+		ka.ReapplyManifestsOnUpdate = tftypes.BoolValue(false)
+	} else {
+		ka.ReapplyManifestsOnUpdate = plan.ReapplyManifestsOnUpdate
+	}
 	labels, d := tftypes.MapValueFrom(ctx, tftypes.StringType, apiKargoAgent.GetData().GetLabels())
 	if d.HasError() {
 		labels = tftypes.MapNull(tftypes.StringType)

--- a/akp/types/kargoagent.go
+++ b/akp/types/kargoagent.go
@@ -20,6 +20,7 @@ type KargoAgent struct {
 	Spec                          *KargoAgentSpec `tfsdk:"spec"`
 	Kubeconfig                    *Kubeconfig     `tfsdk:"kube_config"`
 	RemoveAgentResourcesOnDestroy types.Bool      `tfsdk:"remove_agent_resources_on_destroy"`
+	ReapplyManifestsOnUpdate      types.Bool      `tfsdk:"reapply_manifests_on_update"`
 }
 
 type KargoAgents struct {

--- a/akp/types/types.go
+++ b/akp/types/types.go
@@ -175,6 +175,11 @@ func (c *Cluster) Update(ctx context.Context, diagnostics *diag.Diagnostics, api
 	if c.RemoveAgentResourcesOnDestroy.IsUnknown() || c.RemoveAgentResourcesOnDestroy.IsNull() {
 		c.RemoveAgentResourcesOnDestroy = tftypes.BoolValue(true)
 	}
+	if c.ReapplyManifestsOnUpdate.IsUnknown() || c.ReapplyManifestsOnUpdate.IsNull() {
+		c.ReapplyManifestsOnUpdate = tftypes.BoolValue(false)
+	} else {
+		c.ReapplyManifestsOnUpdate = plan.ReapplyManifestsOnUpdate
+	}
 	labels, d := tftypes.MapValueFrom(ctx, tftypes.StringType, apiCluster.GetData().GetLabels())
 	if d.HasError() {
 		labels = tftypes.MapNull(tftypes.StringType)

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -38,6 +38,7 @@ data "akp_cluster" "example" {
 - `kube_config` (Attributes) Kubernetes connection settings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--kube_config))
 - `labels` (Map of String) Labels
 - `namespace` (String) Agent installation namespace
+- `reapply_manifests_on_update` (Boolean) Whether to reapply manifests on update
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster
 - `spec` (Attributes) Cluster spec (see [below for nested schema](#nestedatt--spec))
 

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -49,6 +49,7 @@ Read-Only:
 - `kube_config` (Attributes) Kubernetes connection settings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--clusters--kube_config))
 - `labels` (Map of String) Labels
 - `namespace` (String) Agent installation namespace
+- `reapply_manifests_on_update` (Boolean) Whether to reapply manifests on update
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster
 - `spec` (Attributes) Cluster spec (see [below for nested schema](#nestedatt--clusters--spec))
 

--- a/docs/data-sources/kargo_agent.md
+++ b/docs/data-sources/kargo_agent.md
@@ -33,6 +33,7 @@ data "akp_kargo_agent" "example" {
 - `kube_config` (Attributes) The kubeconfig of the Kargo agent (see [below for nested schema](#nestedatt--kube_config))
 - `labels` (Map of String) The labels of the Kargo agent
 - `namespace` (String) The namespace of the Kargo agent
+- `reapply_manifests_on_update` (Boolean) Whether to reapply manifests on update
 - `remove_agent_resources_on_destroy` (Boolean) Whether to remove agent resources on destroy
 - `spec` (Attributes) The spec of the Kargo agent (see [below for nested schema](#nestedatt--spec))
 - `workspace` (String) Workspace name for the Kargo agent

--- a/docs/data-sources/kargo_agents.md
+++ b/docs/data-sources/kargo_agents.md
@@ -49,6 +49,7 @@ Read-Only:
 - `kube_config` (Attributes) The kubeconfig of the Kargo agent (see [below for nested schema](#nestedatt--agents--kube_config))
 - `labels` (Map of String) The labels of the Kargo agent
 - `namespace` (String) The namespace of the Kargo agent
+- `reapply_manifests_on_update` (Boolean) Whether to reapply manifests on update
 - `remove_agent_resources_on_destroy` (Boolean) Whether to remove agent resources on destroy
 - `spec` (Attributes) The spec of the Kargo agent (see [below for nested schema](#nestedatt--agents--spec))
 - `workspace` (String) Workspace name for the Kargo agent

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -252,6 +252,7 @@ resource "akp_cluster" "example" {
 - `annotations` (Map of String) Annotations
 - `kube_config` (Attributes) Kubernetes connection settings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--kube_config))
 - `labels` (Map of String) Labels
+- `reapply_manifests_on_update` (Boolean) If true, re-apply generated Argo CD agent manifests to the target cluster on every update when `kube_config` is provided.
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster, default to `true`
 
 ### Read-Only

--- a/docs/resources/kargo_agent.md
+++ b/docs/resources/kargo_agent.md
@@ -106,6 +106,7 @@ EOT
 - `kube_config` (Attributes) Kubernetes connection settings. If configured, terraform will try to connect to the cluster and install the agent (see [below for nested schema](#nestedatt--kube_config))
 - `labels` (Map of String) Labels
 - `namespace` (String) The namespace of the Kargo agent
+- `reapply_manifests_on_update` (Boolean) If true, re-apply generated agent manifests to the target cluster on every update when `kube_config` is provided.
 - `remove_agent_resources_on_destroy` (Boolean) Remove agent Kubernetes resources from the managed cluster when destroying cluster, default to `true`
 - `workspace` (String) Workspace name for the Kargo agent
 


### PR DESCRIPTION
Currently, if there's any failure, the provider won't be able to retry unless re-create the cluster.