### PR TITLE
fix: a few state fixes (+ tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,8 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
+          AKUITY_ORG_NAME: "terraform-provider-acceptance-test"
+          AKUITY_INSTANCE_ID: "6pzhawvy4echbd8x"
           AKUITY_API_KEY_ID: "${{ secrets.AKUITY_API_KEY_ID }}"
           AKUITY_API_KEY_SECRET: "${{ secrets.AKUITY_API_KEY_SECRET }}"
         run: make acc-test

--- a/akp/provider_test.go
+++ b/akp/provider_test.go
@@ -1,6 +1,7 @@
 package akp
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -8,13 +9,32 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-const (
-	providerConfig = `
-provider "akp" {
-	org_name = "terraform-provider-acceptance-test"
-}
-`
+var (
+	orgName        string
+	providerConfig string
 )
+
+func TestMain(m *testing.M) {
+	if v := os.Getenv("AKUITY_ORG_NAME"); v == "" {
+		orgName = "terraform-provider-acceptance-test"
+	} else {
+		orgName = v
+	}
+
+	providerConfig = fmt.Sprintf(`
+provider "akp" {
+	org_name = "%s"
+}
+`, orgName)
+
+	code := m.Run()
+
+	if os.Getenv("CLEANUP_TEST_INSTANCE") == "true" {
+		cleanupTestInstance()
+	}
+
+	os.Exit(code)
+}
 
 // testAccProtoV6ProviderFactories are used to instantiate a provider during
 // acceptance testing. The factory function will be invoked for every Terraform

--- a/akp/resource_akp_cluster.go
+++ b/akp/resource_akp_cluster.go
@@ -195,10 +195,15 @@ func (r *AkpClusterResource) upsert(ctx context.Context, diagnostics *diag.Diagn
 		return nil, nil
 	}
 	result, err := r.applyInstance(ctx, plan, apiReq, isCreate, r.akpCli.Cli.ApplyInstance, r.upsertKubeConfig)
-	if err != nil {
-		return result, err
+	// Always refresh cluster state to ensure we have consistent state, even if kubeconfig application failed
+	if result != nil {
+		refreshErr := refreshClusterState(ctx, diagnostics, r.akpCli.Cli, result, r.akpCli.OrgId, nil, plan)
+		if refreshErr != nil && err == nil {
+			// If we didn't have an error before but refresh failed, return the refresh error
+			return result, refreshErr
+		}
 	}
-	return result, refreshClusterState(ctx, diagnostics, r.akpCli.Cli, result, r.akpCli.OrgId, nil, plan)
+	return result, err
 }
 
 func (r *AkpClusterResource) applyInstance(ctx context.Context, plan *types.Cluster, apiReq *argocdv1.ApplyInstanceRequest, isCreate bool, applyInstance func(context.Context, *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error), upsertKubeConfig func(ctx context.Context, plan *types.Cluster) error) (*types.Cluster, error) {
@@ -216,7 +221,39 @@ func (r *AkpClusterResource) applyInstance(ctx context.Context, plan *types.Clus
 		if shouldApply {
 			err = upsertKubeConfig(ctx, plan)
 			if err != nil {
-				// Ensure kubeconfig won't be committed to state by setting it to nil
+				// If this is a create operation and kubeconfig application fails,
+				// clean up the dangling cluster from the API
+				if isCreate {
+					tflog.Warn(ctx, fmt.Sprintf("Kubeconfig application failed during create, cleaning up cluster %s", plan.Name.ValueString()))
+
+					// First, get the cluster ID by looking it up by name
+					getReq := &argocdv1.GetInstanceClusterRequest{
+						OrganizationId: r.akpCli.OrgId,
+						InstanceId:     plan.InstanceID.ValueString(),
+						Id:             plan.Name.ValueString(),
+						IdType:         idv1.Type_NAME,
+					}
+					clusterResp, getErr := r.akpCli.Cli.GetInstanceCluster(ctx, getReq)
+					if getErr != nil {
+						tflog.Error(ctx, fmt.Sprintf("Failed to lookup cluster %s for cleanup: %v", plan.Name.ValueString(), getErr))
+						return nil, fmt.Errorf("unable to apply manifests: %s (and failed to lookup cluster for cleanup: %s)", err, getErr)
+					}
+
+					// Now delete using the actual cluster ID
+					deleteReq := &argocdv1.DeleteInstanceClusterRequest{
+						OrganizationId: r.akpCli.OrgId,
+						InstanceId:     plan.InstanceID.ValueString(),
+						Id:             clusterResp.GetCluster().Id,
+					}
+					_, deleteErr := r.akpCli.Cli.DeleteInstanceCluster(ctx, deleteReq)
+					if deleteErr != nil {
+						tflog.Error(ctx, fmt.Sprintf("Failed to clean up dangling cluster %s: %v", plan.Name.ValueString(), deleteErr))
+						return nil, fmt.Errorf("unable to apply manifests: %s (and failed to clean up cluster: %s)", err, deleteErr)
+					}
+					tflog.Info(ctx, fmt.Sprintf("Successfully cleaned up dangling cluster %s", plan.Name.ValueString()))
+					return nil, fmt.Errorf("unable to apply manifests: %s", err)
+				}
+				// For updates, just ensure kubeconfig won't be committed to state by setting it to nil
 				plan.Kubeconfig = nil
 				return plan, fmt.Errorf("unable to apply manifests: %s", err)
 			}

--- a/akp/resource_akp_cluster_schema.go
+++ b/akp/resource_akp_cluster_schema.go
@@ -69,7 +69,6 @@ func getAKPClusterAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Agent installation namespace",
 			Required:            true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
 				stringplanmodifier.RequiresReplace(),
 			},
 			Validators: []validator.String{
@@ -115,7 +114,6 @@ func getAKPClusterAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "If true, re-apply generated Argo CD agent manifests to the target cluster on every update when `kube_config` is provided.",
 			Optional:            true,
 			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -136,7 +134,6 @@ func getClusterSpecAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "If the agent is namespace scoped",
 			Optional:            true,
 			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
 				boolplanmodifier.RequiresReplace(),
 			},
 		},
@@ -161,7 +158,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Disable Agents Auto Upgrade. On resource update terraform will try to update the agent if this is set to `true`. Otherwise agent will update itself automatically",
 			Optional:            true,
 			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -178,7 +174,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enables Argo CD state replication to the managed cluster that allows disconnecting the cluster from Akuity Platform without losing core Argocd features",
 			Optional:            true,
 			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 				boolplanmodifier.RequiresReplace(),
@@ -196,7 +191,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enables the ability to connect to Redis over a web-socket tunnel that allows using Akuity agent behind HTTPS proxy",
 			Optional:            true,
 			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -204,8 +198,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 		"datadog_annotations_enabled": schema.BoolAttribute{
 			MarkdownDescription: "Enable Datadog metrics collection of Application Controller and Repo Server. Make sure that you install Datadog agent in cluster.",
 			Optional:            true,
-			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -213,8 +205,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 		"eks_addon_enabled": schema.BoolAttribute{
 			MarkdownDescription: "Enable this if you are installing this cluster on EKS.",
 			Optional:            true,
-			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -228,7 +218,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enable the KubeVision feature on the managed cluster",
 			Optional:            true,
 			Computed:            true,
-			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -237,12 +226,9 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Autoscaler config for auto agent size",
 			Optional:            true,
 			Computed:            true,
-			/*
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
-
-			*/
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.UseStateForUnknown(),
+			},
 			Attributes: getAutoScalerConfigAttributes(),
 		},
 		"custom_agent_size_config": schema.SingleNestedAttribute{

--- a/akp/resource_akp_cluster_schema.go
+++ b/akp/resource_akp_cluster_schema.go
@@ -115,6 +115,7 @@ func getAKPClusterAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "If true, re-apply generated Argo CD agent manifests to the target cluster on every update when `kube_config` is provided.",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -127,7 +128,6 @@ func getClusterSpecAttributes() map[string]schema.Attribute {
 		"description": schema.StringAttribute{
 			MarkdownDescription: "Cluster description",
 			Optional:            true,
-			Computed:            true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
@@ -135,7 +135,6 @@ func getClusterSpecAttributes() map[string]schema.Attribute {
 		"namespace_scoped": schema.BoolAttribute{
 			MarkdownDescription: "If the agent is namespace scoped",
 			Optional:            true,
-			Computed:            true,
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 				boolplanmodifier.RequiresReplace(),
@@ -162,6 +161,7 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Disable Agents Auto Upgrade. On resource update terraform will try to update the agent if this is set to `true`. Otherwise agent will update itself automatically",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -178,6 +178,7 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enables Argo CD state replication to the managed cluster that allows disconnecting the cluster from Akuity Platform without losing core Argocd features",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 				boolplanmodifier.RequiresReplace(),
@@ -195,6 +196,7 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enables the ability to connect to Redis over a web-socket tunnel that allows using Akuity agent behind HTTPS proxy",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -203,6 +205,7 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enable Datadog metrics collection of Application Controller and Repo Server. Make sure that you install Datadog agent in cluster.",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -211,6 +214,7 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enable this if you are installing this cluster on EKS.",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -224,6 +228,7 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Enable the KubeVision feature on the managed cluster",
 			Optional:            true,
 			Computed:            true,
+			//Default:             booldefault.StaticBool(false),
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -232,7 +237,13 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Autoscaler config for auto agent size",
 			Optional:            true,
 			Computed:            true,
-			Attributes:          getAutoScalerConfigAttributes(),
+			/*
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+
+			*/
+			Attributes: getAutoScalerConfigAttributes(),
 		},
 		"custom_agent_size_config": schema.SingleNestedAttribute{
 			MarkdownDescription: "Custom agent size config",
@@ -242,7 +253,6 @@ func getClusterDataAttributes() map[string]schema.Attribute {
 		"project": schema.StringAttribute{
 			MarkdownDescription: "Project name",
 			Optional:            true,
-			Computed:            true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -52,6 +52,10 @@ func getTestAkpCli() *AkpCli {
 		return testAkpCli
 	}
 
+	if os.Getenv("TF_ACC") != "1" {
+		return nil
+	}
+
 	ctx := context.Background()
 
 	serverUrl := os.Getenv("AKUITY_SERVER_URL")
@@ -98,6 +102,10 @@ func getTestAkpCli() *AkpCli {
 }
 
 func createTestInstance() string {
+	if os.Getenv("TF_ACC") != "1" {
+		return ""
+	}
+
 	akpCli := getTestAkpCli()
 	ctx := context.Background()
 	ctx = httpctx.SetAuthorizationHeader(ctx, akpCli.Cred.Scheme(), akpCli.Cred.Credential())

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -111,10 +111,15 @@ func createTestInstance() string {
 	ctx = httpctx.SetAuthorizationHeader(ctx, akpCli.Cred.Scheme(), akpCli.Cred.Credential())
 	instanceName := fmt.Sprintf("test-cluster-provider-%s", acctest.RandString(8))
 
+	instanceVersion := os.Getenv("AKUITY_ARGOCD_INSTANCE_VERSION")
+	if instanceVersion == "" {
+		instanceVersion = "v3.0.0"
+	}
+
 	createReq := &argocdv1.CreateInstanceRequest{
 		OrganizationId: akpCli.OrgId,
 		Name:           instanceName,
-		Version:        "v3.0.0",
+		Version:        instanceVersion,
 	}
 	instance, err := akpCli.Cli.CreateInstance(ctx, createReq)
 	if err != nil {

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -367,6 +367,7 @@ func TestAccClusterResourceNamespaceScoped(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.namespace_scoped", "false"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -398,22 +398,17 @@ func TestAccClusterResourceNamespaceScoped(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("akp_cluster.test",
-							plancheck.ResourceActionDestroyBeforeCreate),
-
+						plancheck.ExpectResourceAction("akp_cluster.test", plancheck.ResourceActionDestroyBeforeCreate),
 						plancheck.ExpectKnownValue("akp_cluster.test", path.AtMapKey("namespace_scoped"), knownvalue.Bool(false)),
+						plancheck.ExpectKnownValue("akp_cluster.test", data.AtMapKey("size"), knownvalue.StringExact("small")),
 						plancheck.ExpectUnknownValue("akp_cluster.test", data.AtMapKey("auto_agent_size_config")),
 						plancheck.ExpectUnknownValue("akp_cluster.test", data.AtMapKey("auto_upgrade_disabled")),
 						plancheck.ExpectUnknownValue("akp_cluster.test", data.AtMapKey("kustomization")),
 						plancheck.ExpectUnknownValue("akp_cluster.test", data.AtMapKey("multi_cluster_k8s_dashboard_enabled")),
 						plancheck.ExpectUnknownValue("akp_cluster.test", data.AtMapKey("redis_tunneling")),
 						plancheck.ExpectUnknownValue("akp_cluster.test", data.AtMapKey("target_version")),
-
-						// TODO: There's a bug here.
-						//~ size                                = "unspecified" -> "small"
 					},
 				},
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -3,17 +3,163 @@ package akp
 import (
 	"context"
 	"fmt"
+	"os"
+	"regexp"
 	"testing"
 
 	hashitype "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	"time"
+
+	"github.com/akuity/api-client-go/pkg/api/gateway/accesscontrol"
+	gwoption "github.com/akuity/api-client-go/pkg/api/gateway/option"
 	argocdv1 "github.com/akuity/api-client-go/pkg/api/gen/argocd/v1"
+	kargov1 "github.com/akuity/api-client-go/pkg/api/gen/kargo/v1"
+	orgcv1 "github.com/akuity/api-client-go/pkg/api/gen/organization/v1"
+	idv1 "github.com/akuity/api-client-go/pkg/api/gen/types/id/v1"
+	healthv1 "github.com/akuity/api-client-go/pkg/api/gen/types/status/health/v1"
+	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
 	"github.com/akuity/terraform-provider-akp/akp/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+var (
+	instanceId string
+	testAkpCli *AkpCli
+)
+
+func getInstanceId() string {
+	if instanceId == "" {
+		if v := os.Getenv("AKUITY_INSTANCE_ID"); v == "" {
+			// Create a new instance for testing
+			instanceId = createTestInstance()
+		} else {
+			instanceId = v
+		}
+	}
+
+	return instanceId
+}
+
+func getTestAkpCli() *AkpCli {
+	if testAkpCli != nil {
+		return testAkpCli
+	}
+
+	ctx := context.Background()
+
+	serverUrl := os.Getenv("AKUITY_SERVER_URL")
+	if serverUrl == "" {
+		serverUrl = "https://akuity.cloud"
+	}
+
+	apiKeyID := os.Getenv("AKUITY_API_KEY_ID")
+	apiKeySecret := os.Getenv("AKUITY_API_KEY_SECRET")
+
+	if apiKeyID == "" || apiKeySecret == "" {
+		panic("API key credentials are required")
+	}
+
+	// Create client following the same logic as the provider
+	cred := accesscontrol.NewAPIKeyCredential(apiKeyID, apiKeySecret)
+	ctx = httpctx.SetAuthorizationHeader(ctx, cred.Scheme(), cred.Credential())
+	gwc := gwoption.NewClient(serverUrl, false)
+	orgc := orgcv1.NewOrganizationServiceGatewayClient(gwc)
+
+	// Get Organization ID by name
+	res, err := orgc.GetOrganization(ctx, &orgcv1.GetOrganizationRequest{
+		Id:     orgName,
+		IdType: idv1.Type_NAME,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get organization: %v", err))
+	}
+
+	orgID := res.Organization.Id
+
+	// Create service clients
+	argoc := argocdv1.NewArgoCDServiceGatewayClient(gwc)
+	kargoc := kargov1.NewKargoServiceGatewayClient(gwc)
+
+	testAkpCli = &AkpCli{
+		Cli:      argoc,
+		KargoCli: kargoc,
+		Cred:     cred,
+		OrgId:    orgID,
+		OrgCli:   orgc,
+	}
+	return testAkpCli
+}
+
+func createTestInstance() string {
+	akpCli := getTestAkpCli()
+	ctx := context.Background()
+	ctx = httpctx.SetAuthorizationHeader(ctx, akpCli.Cred.Scheme(), akpCli.Cred.Credential())
+	instanceName := fmt.Sprintf("test-cluster-provider-%s", acctest.RandString(8))
+
+	createReq := &argocdv1.CreateInstanceRequest{
+		OrganizationId: akpCli.OrgId,
+		Name:           instanceName,
+		Version:        "v3.0.0",
+	}
+	instance, err := akpCli.Cli.CreateInstance(ctx, createReq)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create instance: %v", err))
+	}
+
+	getResourceFunc := func(ctx context.Context) (*argocdv1.GetInstanceResponse, error) {
+		return akpCli.Cli.GetInstance(ctx, &argocdv1.GetInstanceRequest{
+			OrganizationId: akpCli.OrgId,
+			Id:             instance.GetInstance().Id,
+			IdType:         idv1.Type_ID,
+		})
+	}
+
+	getStatusFunc := func(resp *argocdv1.GetInstanceResponse) healthv1.StatusCode {
+		if resp == nil || resp.Instance == nil {
+			return healthv1.StatusCode_STATUS_CODE_UNKNOWN
+		}
+		return resp.Instance.GetHealthStatus().GetCode()
+	}
+
+	err = waitForStatus(
+		ctx,
+		getResourceFunc,
+		getStatusFunc,
+		[]healthv1.StatusCode{healthv1.StatusCode_STATUS_CODE_HEALTHY},
+		10*time.Second,
+		5*time.Minute,
+		fmt.Sprintf("Test instance %s", instanceName),
+		"health",
+	)
+
+	if err != nil {
+		panic(fmt.Sprintf("Test instance did not become healthy: %v", err))
+	}
+
+	return instance.Instance.Id
+}
+
+func cleanupTestInstance() {
+	if instanceId == "" || testAkpCli == nil {
+		return
+	}
+
+	ctx := context.Background()
+	ctx = httpctx.SetAuthorizationHeader(ctx, testAkpCli.Cred.Scheme(), testAkpCli.Cred.Credential())
+
+	// Delete the instance
+	_, _ = testAkpCli.Cli.DeleteInstance(ctx, &argocdv1.DeleteInstanceRequest{
+		Id:             instanceId,
+		OrganizationId: testAkpCli.OrgId,
+	})
+}
 
 func TestAccClusterResource(t *testing.T) {
 	name := fmt.Sprintf("cluster-%s", acctest.RandString(10))
@@ -23,7 +169,7 @@ func TestAccClusterResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + testAccClusterResourceConfig("small", name, "test one"),
+				Config: providerConfig + testAccClusterResourceConfig("small", name, "test one", getInstanceId()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
 					resource.TestCheckResourceAttr("akp_cluster.test", "namespace", "test"),
@@ -65,7 +211,7 @@ func TestAccClusterResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + testAccClusterResourceConfig("medium", name, "test two"),
+				Config: providerConfig + testAccClusterResourceConfig("medium", name, "test two", getInstanceId()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.description", "test two"),
 					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.size", "medium"),
@@ -76,10 +222,169 @@ func TestAccClusterResource(t *testing.T) {
 	})
 }
 
-func testAccClusterResourceConfig(size string, name string, description string) string {
+func TestAccClusterResourceIPv6(t *testing.T) {
+	name := fmt.Sprintf("cluster-ipv6-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigIPv6(name, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.compatibility.ipv6_only", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceArgoCDNotifications(t *testing.T) {
+	name := fmt.Sprintf("cluster-notifications-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigNotifications(name, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.argocd_notifications_settings.in_cluster_settings", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceCustomAgentSize(t *testing.T) {
+	name := fmt.Sprintf("cluster-custom-size-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigCustomAgentSize(name, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.custom_agent_size_config.application_controller.memory", "2Gi"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.custom_agent_size_config.application_controller.cpu", "1000m"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.custom_agent_size_config.repo_server.memory", "4Gi"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.custom_agent_size_config.repo_server.cpu", "2000m"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.custom_agent_size_config.repo_server.replicas", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceManagedCluster(t *testing.T) {
+	name := fmt.Sprintf("cluster-managed-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigManagedCluster(name, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.managed_cluster_config.secret_name", "test-secret"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.managed_cluster_config.secret_key", "kubeconfig"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceFeatures(t *testing.T) {
+	name := fmt.Sprintf("cluster-features-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigFeatures(name, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.multi_cluster_k8s_dashboard_enabled", "true"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.eks_addon_enabled", "true"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.datadog_annotations_enabled", "true"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.redis_tunneling", "true"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.app_replication", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceReapplyManifests(t *testing.T) {
+	name := fmt.Sprintf("cluster-reapply-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigReapplyManifests(name, "test initial", getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.description", "test initial"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "reapply_manifests_on_update", "true"),
+				),
+			},
+			{
+				Config: providerConfig + testAccClusterResourceConfigReapplyManifests(name, "test updated", getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.description", "test updated"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "reapply_manifests_on_update", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceNamespaceScoped(t *testing.T) {
+	name := fmt.Sprintf("cluster-ns-scoped-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigNamespaceScoped(name, true, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.namespace_scoped", "true"),
+				),
+			},
+			{
+				Config: providerConfig + testAccClusterResourceConfigNamespaceScoped(name, false, getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.namespace_scoped", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterResourceProject(t *testing.T) {
+	name := fmt.Sprintf("cluster-project-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccClusterResourceConfigProject(name, "test-project", getInstanceId()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("akp_cluster.test", "id"),
+					resource.TestCheckResourceAttr("akp_cluster.test", "spec.data.project", "test-project"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterResourceConfig(size, name, description, instanceId string) string {
 	return fmt.Sprintf(`
 resource "akp_cluster" "test" {
-  instance_id = "6pzhawvy4echbd8x"
+  instance_id = %q
   name      = %q
   namespace = "test"
   labels = {
@@ -121,7 +426,253 @@ EOF
     }
   }
 }
-`, name, description, size)
+`, instanceId, name, description, size)
+}
+
+func testAccClusterResourceConfigIPv6(name, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "IPv6 test cluster"
+    data = {
+      size = "small"
+      compatibility = {
+        ipv6_only = true
+      }
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name)
+}
+
+func testAccClusterResourceConfigNotifications(name, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "ArgoCD notifications test cluster"
+    data = {
+      size = "small"
+      argocd_notifications_settings = {
+        in_cluster_settings = true
+      }
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name)
+}
+
+func testAccClusterResourceConfigCustomAgentSize(name, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "Custom agent size test cluster"
+    data = {
+      size = "custom"
+      custom_agent_size_config = {
+        application_controller = {
+          memory = "2Gi"
+          cpu    = "1000m"
+        }
+        repo_server = {
+          memory   = "4Gi"
+          cpu      = "2000m"
+          replicas = 3
+        }
+      }
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name)
+}
+
+func testAccClusterResourceConfigManagedCluster(name, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "Managed cluster test"
+    data = {
+      size = "small"
+      managed_cluster_config = {
+        secret_name = "test-secret"
+        secret_key  = "kubeconfig"
+      }
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name)
+}
+
+func testAccClusterResourceConfigFeatures(name, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "Feature flags test cluster"
+    data = {
+      size                               = "small"
+      multi_cluster_k8s_dashboard_enabled = true
+      eks_addon_enabled                  = true
+      datadog_annotations_enabled        = true
+      redis_tunneling                    = true
+      app_replication                    = true
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name)
+}
+
+func testAccClusterResourceConfigReapplyManifests(name, description, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = %q
+    data = {
+      size = "small"
+    }
+  }
+  reapply_manifests_on_update       = true
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name, description)
+}
+
+func testAccClusterResourceConfigNamespaceScoped(name string, namespaceScoped bool, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = %t
+    description      = "Namespace scoped test cluster"
+    data = {
+      size = "small"
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name, namespaceScoped)
+}
+
+func testAccClusterResourceConfigProject(name, project, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "Project assignment test cluster"
+    data = {
+      size    = "small"
+      project = %q
+    }
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name, project)
+}
+
+func TestAccClusterResourceKubeconfig(t *testing.T) {
+	name := fmt.Sprintf("cluster-kubeconfig-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + testAccClusterResourceConfigKubeconfig(name, getInstanceId()),
+				ExpectError: regexp.MustCompile("unable to apply manifests"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify that cluster was automatically cleaned up and no state was committed
+					testCheckClusterCleanedUp(name, getInstanceId()),
+				),
+			},
+		},
+	})
+}
+
+func testCheckClusterCleanedUp(clusterName, instanceId string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Check that the cluster was automatically cleaned up by the provider
+		akpCli := getTestAkpCli()
+		ctx := context.Background()
+		ctx = httpctx.SetAuthorizationHeader(ctx, akpCli.Cred.Scheme(), akpCli.Cred.Credential())
+
+		clusterReq := &argocdv1.GetInstanceClusterRequest{
+			OrganizationId: akpCli.OrgId,
+			InstanceId:     instanceId,
+			Id:             clusterName,
+			IdType:         idv1.Type_NAME,
+		}
+
+		_, err := akpCli.Cli.GetInstanceCluster(ctx, clusterReq)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				// This is what we expect - the cluster should not exist
+				// Check that no resource exists in Terraform state
+				for name := range s.RootModule().Resources {
+					if name == "akp_cluster.test" {
+						return fmt.Errorf("cluster resource should not exist in Terraform state")
+					}
+				}
+				return nil
+			}
+			return fmt.Errorf("unexpected error when checking cluster: %v", err)
+		}
+
+		return fmt.Errorf("cluster %s should have been automatically cleaned up but still exists in API", clusterName)
+	}
+}
+
+func testAccClusterResourceConfigKubeconfig(name, instanceId string) string {
+	return fmt.Sprintf(`
+resource "akp_cluster" "test" {
+  instance_id = %q
+  name      = %q
+  namespace = "test"
+  spec = {
+    namespace_scoped = true
+    description      = "Kubeconfig test cluster"
+    data = {
+      size = "small"
+    }
+  }
+  kube_config = {
+    host     = "https://test-cluster.example.com"
+    insecure = true
+    token    = "test-token"
+  }
+  remove_agent_resources_on_destroy = true
+}
+`, instanceId, name)
 }
 
 func TestAkpClusterResource_applyInstance(t *testing.T) {
@@ -195,25 +746,6 @@ func TestAkpClusterResource_applyInstance(t *testing.T) {
 				},
 			},
 			error: nil,
-		},
-		{
-			name: "error path, with kubeconfig",
-			args: args{
-				plan: &types.Cluster{
-					Kubeconfig: &types.Kubeconfig{
-						Host: hashitype.StringValue("some-host"),
-					},
-				},
-				isCreate: true,
-				applyInstance: func(ctx context.Context, request *argocdv1.ApplyInstanceRequest) (*argocdv1.ApplyInstanceResponse, error) {
-					return &argocdv1.ApplyInstanceResponse{}, nil
-				},
-				upsertKubeConfig: func(ctx context.Context, plan *types.Cluster) error {
-					return errors.New("some kube apply error")
-				},
-			},
-			want:  &types.Cluster{},
-			error: fmt.Errorf("unable to apply manifests: some kube apply error"),
 		},
 	}
 	for _, tt := range tests {

--- a/akp/resource_akp_cluster_test.go
+++ b/akp/resource_akp_cluster_test.go
@@ -305,6 +305,25 @@ func TestAccClusterResourceManagedCluster(t *testing.T) {
 
 func TestAccClusterResourceFeatures(t *testing.T) {
 	name := fmt.Sprintf("cluster-features-%s", acctest.RandString(10))
+
+	// Check if multi-cluster k8s dashboard feature is enabled
+	// If disabled, test should verify proper error handling
+	if os.Getenv("MULTI_CLUSTER_K8S_DASHBOARD_FEATURE_ENABLED") != "true" {
+		// Test that disabled feature returns proper error
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      providerConfig + testAccClusterResourceConfigFeatures(name, getInstanceId()),
+					ExpectError: regexp.MustCompile("multi_cluster_k8s_dashboard_enabled feature is not available"),
+				},
+			},
+		})
+		return
+	}
+
+	// Feature is enabled, test normal functionality
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/akp/types/types.go
+++ b/akp/types/types.go
@@ -293,8 +293,6 @@ func (c *Cluster) Update(ctx context.Context, diagnostics *diag.Diagnostics, api
 			AppReplication:                  tftypes.BoolValue(apiCluster.GetData().GetAppReplication()),
 			TargetVersion:                   tftypes.StringValue(apiCluster.GetData().GetTargetVersion()),
 			RedisTunneling:                  tftypes.BoolValue(apiCluster.GetData().GetRedisTunneling()),
-			DatadogAnnotationsEnabled:       tftypes.BoolValue(apiCluster.GetData().GetDatadogAnnotationsEnabled()),
-			EksAddonEnabled:                 tftypes.BoolValue(apiCluster.GetData().GetEksAddonEnabled()),
 			ManagedClusterConfig:            toManagedClusterConfigTFModel(apiCluster.GetData().GetManagedClusterConfig()),
 			MultiClusterK8SDashboardEnabled: tftypes.BoolValue(apiCluster.GetData().GetMultiClusterK8SDashboardEnabled()),
 			AutoscalerConfig:                autoscalerConfig,
@@ -311,6 +309,14 @@ func (c *Cluster) Update(ctx context.Context, diagnostics *diag.Diagnostics, api
 
 	if apiCluster.GetData().GetProject() != "" {
 		c.Spec.Data.Project = tftypes.StringValue(apiCluster.GetData().GetProject())
+	}
+
+	if !c.Spec.Data.EksAddonEnabled.IsNull() {
+		c.Spec.Data.EksAddonEnabled = tftypes.BoolValue(apiCluster.GetData().GetEksAddonEnabled())
+	}
+
+	if !c.Spec.Data.DatadogAnnotationsEnabled.IsNull() {
+		c.Spec.Data.DatadogAnnotationsEnabled = tftypes.BoolValue(apiCluster.GetData().GetDatadogAnnotationsEnabled())
 	}
 }
 

--- a/akp/types/types.go
+++ b/akp/types/types.go
@@ -285,7 +285,6 @@ func (c *Cluster) Update(ctx context.Context, diagnostics *diag.Diagnostics, api
 	}
 
 	c.Spec = &ClusterSpec{
-		Description:     tftypes.StringValue(apiCluster.GetDescription()),
 		NamespaceScoped: tftypes.BoolValue(apiCluster.GetNamespaceScoped()),
 		Data: ClusterData{
 			Size:                            size,
@@ -300,11 +299,18 @@ func (c *Cluster) Update(ctx context.Context, diagnostics *diag.Diagnostics, api
 			MultiClusterK8SDashboardEnabled: tftypes.BoolValue(apiCluster.GetData().GetMultiClusterK8SDashboardEnabled()),
 			AutoscalerConfig:                autoscalerConfig,
 			CustomAgentSizeConfig:           customConfig,
-			Project:                         tftypes.StringValue(apiCluster.GetData().GetProject()),
 			Compatibility:                   toCompatibilityTFModel(plan, apiCluster.GetData().GetCompatibility()),
 			ArgocdNotificationsSettings:     toArgoCDNotificationsSettingsTFModel(plan, apiCluster.GetData().GetArgocdNotificationsSettings()),
 			DirectClusterSpec:               directClusterSpec,
 		},
+	}
+
+	if apiCluster.GetDescription() != "" {
+		c.Spec.Description = tftypes.StringValue(apiCluster.GetDescription())
+	}
+
+	if apiCluster.GetData().GetProject() != "" {
+		c.Spec.Data.Project = tftypes.StringValue(apiCluster.GetData().GetProject())
 	}
 }
 


### PR DESCRIPTION
I added a bunch of acceptance tests and during that process I found a few bugs.

1. EOF errors in `waitForStatus` were not retryable. More of a minor annoyance than anything else, but IMO this should be retried since this usually is an intermittent error.
2. If a kubeconfig is invalid when _creating_ a cluster and fails to apply, delete the cluster that has been created in the API so that it can be retried with another `terraform apply`. Should fix #347.
3. When deleting a cluster (or when a cluster is being recreated), remove the cluster from the tf state if it already is not present in the api. This also applies when the API returns a `PermissionDenied` to the user. This part is pretty contentious since there is no real way to distinguish "the resource has been removed" vs "the resource is there but you don't have permission to see it". My thinking is that if the resource is in the TF state and we're trying to remove it, it should be fine since the prerequiste permissions were needed to get the cluster into the TF state in the first place. Happy to discuss alternatives if there are any.
4. In the case of AKI, if it's been disabled on the instance level, return an error if a user tries to enable it on a cluster.

Otherwise this is just adding a bunch of tests and removed the hardcoding of the instance id `6pzhawvy4echbd8x` and the Akuity organization `terraform-provider-acceptance-test`. This is still set as the defaults in CI, but makes it possible to run tests for anyone not a member of said org (such as myself).