### PR TITLE
fix: improve resilience against transient API errors

### DIFF
--- a/akp/provider.go
+++ b/akp/provider.go
@@ -139,10 +139,12 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	ctx = httpctx.SetAuthorizationHeader(ctx, cred.Scheme(), cred.Credential())
 	gwc := gwoption.NewClient(ServerUrl, skipTLSVerify)
 	orgc := orgcv1.NewOrganizationServiceGatewayClient(gwc)
-	res, err := orgc.GetOrganization(ctx, &orgcv1.GetOrganizationRequest{
-		Id:     orgName,
-		IdType: idv1.Type_NAME,
-	})
+	res, err := retryWithBackoff(ctx, func(ctx context.Context) (*orgcv1.GetOrganizationResponse, error) {
+		return orgc.GetOrganization(ctx, &orgcv1.GetOrganizationRequest{
+			Id:     orgName,
+			IdType: idv1.Type_NAME,
+		})
+	}, "GetOrganization")
 	tflog.Debug(ctx, fmt.Sprintf("Res: %s", res))
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/akp/resource_helpers.go
+++ b/akp/resource_helpers.go
@@ -161,8 +161,8 @@ func isRetryableError(err error) bool {
 			codes.DeadlineExceeded,
 			codes.Aborted,
 			codes.ResourceExhausted,
-			codes.Canceled,
-			codes.Internal:
+			codes.Internal,
+			codes.Unknown: // infrastructure-layer failure (empty desc, no JSON body from load balancer)
 			return true
 		case codes.InvalidArgument:
 			// Retry InvalidArgument only if it's due to provisioning delays


### PR DESCRIPTION
## Summary

- Wraps `GetOrganization` in `retryWithBackoff` during provider `Configure` — previously a single transient 503/429 would immediately abort provider initialization with no retry
- Adds `codes.Unknown` to the retryable set — this code indicates an infrastructure-layer failure (load balancer returning a raw error page with no JSON body) rather than an application error, and is worth retrying
- Removes `codes.Canceled` from the retryable set — a server-sent cancellation is not a transient condition; client-side context cancellation never reaches this path anyway (resty wraps it as a plain error that `status.FromError` does not recognize as a gRPC status)

## Context

Investigated a customer report of intermittent `rpc error: code = Unavailable desc =` and `rpc error: code = Unknown desc =` failures in CI workflows. The empty `desc` in both cases indicates responses with no JSON body, consistent with an infrastructure-layer failure (load balancer returning a raw 503/500 during a service disruption). A companion fix to surface the raw HTTP body in the error description is tracked in https://github.com/akuity/grpc-gateway-client/pull/13.

## Test plan

- [ ] Existing acceptance tests pass
- [ ] Manually verify provider initializes successfully under simulated transient network errors