### PR TITLE
nit: Fix grammar in akp provider 

### DIFF
--- a/akp/data_source_akp_cluster_schema.go
+++ b/akp/data_source_akp_cluster_schema.go
@@ -245,7 +245,7 @@ func getKubeconfigDataSourceAttributes() map[string]schema.Attribute {
 		"token": schema.StringAttribute{
 			Computed:    true,
 			Sensitive:   true,
-			Description: "Token to authenticate an service account",
+			Description: "Token to authenticate a service account",
 		},
 		"proxy_url": schema.StringAttribute{
 			Computed:    true,

--- a/akp/data_source_akp_kargoagents_schema.go
+++ b/akp/data_source_akp_kargoagents_schema.go
@@ -21,7 +21,7 @@ func getAKPKargoAgentsDataSourceAttributes() map[string]schema.Attribute {
 			Required:            true,
 		},
 		"id": schema.StringAttribute{
-			MarkdownDescription: "Kaego instance ID",
+			MarkdownDescription: "Kargo instance ID",
 			Computed:            true,
 		},
 		"agents": schema.ListNestedAttribute{

--- a/akp/provider.go
+++ b/akp/provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
 	"github.com/akuity/api-client-go/pkg/api/gateway/accesscontrol"
 	gwoption "github.com/akuity/api-client-go/pkg/api/gateway/option"
 	apikeyv1 "github.com/akuity/api-client-go/pkg/api/gen/apikey/v1"
@@ -21,6 +20,7 @@ import (
 	kargov1 "github.com/akuity/api-client-go/pkg/api/gen/kargo/v1"
 	orgcv1 "github.com/akuity/api-client-go/pkg/api/gen/organization/v1"
 	idv1 "github.com/akuity/api-client-go/pkg/api/gen/types/id/v1"
+	httpctx "github.com/akuity/grpc-gateway-client/pkg/http/context"
 )
 
 var _ provider.Provider = &AkpProvider{}
@@ -112,7 +112,7 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		resp.Diagnostics.AddAttributeError(
 			path.Root("api_key_id"),
 			"Missing Akuity Platform API Key Id",
-			"The provider cannot create the Akuity Platform API client as there is an missing API key. "+
+			"The provider cannot create the Akuity Platform API client as the API key is missing. "+
 				"Use the AKUITY_API_KEY_ID environment variable to configure it.",
 		)
 	}
@@ -120,7 +120,7 @@ func (p *AkpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		resp.Diagnostics.AddAttributeError(
 			path.Root("api_key_secret"),
 			"Missing Akuity Platform API Key Secret",
-			"The provider cannot create the Akuity Platform API client as there is an missing API key. "+
+			"The provider cannot create the Akuity Platform API client as the API key is missing. "+
 				"Use the AKUITY_API_KEY_SECRET environment variable to configure it.",
 		)
 	}

--- a/akp/resource_akp_cluster_schema.go
+++ b/akp/resource_akp_cluster_schema.go
@@ -459,7 +459,7 @@ func getKubeconfigAttributes() map[string]schema.Attribute {
 		"token": schema.StringAttribute{
 			Optional:    true,
 			Sensitive:   true,
-			Description: "Token to authenticate an service account",
+			Description: "Token to authenticate a service account",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -60,7 +60,7 @@ Read-Only:
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
-- `token` (String, Sensitive) Token to authenticate an service account
+- `token` (String, Sensitive) Token to authenticate a service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 
 

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -71,7 +71,7 @@ Read-Only:
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
-- `token` (String, Sensitive) Token to authenticate an service account
+- `token` (String, Sensitive) Token to authenticate a service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 
 

--- a/docs/data-sources/kargo_agent.md
+++ b/docs/data-sources/kargo_agent.md
@@ -55,7 +55,7 @@ Read-Only:
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
-- `token` (String, Sensitive) Token to authenticate an service account
+- `token` (String, Sensitive) Token to authenticate a service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 
 

--- a/docs/data-sources/kargo_agents.md
+++ b/docs/data-sources/kargo_agents.md
@@ -32,7 +32,7 @@ data "akp_kargo_agents" "examples" {
 ### Read-Only
 
 - `agents` (Attributes List) List of Kargo agents (see [below for nested schema](#nestedatt--agents))
-- `id` (String) Kaego instance ID
+- `id` (String) Kargo instance ID
 
 <a id="nestedatt--agents"></a>
 ### Nested Schema for `agents`
@@ -71,7 +71,7 @@ Read-Only:
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
-- `token` (String, Sensitive) Token to authenticate an service account
+- `token` (String, Sensitive) Token to authenticate a service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -473,7 +473,7 @@ Optional:
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
-- `token` (String, Sensitive) Token to authenticate an service account
+- `token` (String, Sensitive) Token to authenticate a service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 
 <a id="nestedatt--kube_config--exec"></a>

--- a/docs/resources/kargo_agent.md
+++ b/docs/resources/kargo_agent.md
@@ -230,7 +230,7 @@ Optional:
 - `insecure` (Boolean) Whether server should be accessed without verifying the TLS certificate.
 - `password` (String, Sensitive) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
-- `token` (String, Sensitive) Token to authenticate an service account
+- `token` (String, Sensitive) Token to authenticate a service account
 - `username` (String) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.
 
 <a id="nestedatt--kube_config--exec"></a>


### PR DESCRIPTION
### Changes
- `provider.go`: "there is an missing API key" -> "the API key is missing"
- `resource_akp_cluster_test.go`: "a invalid size" -> "an invalid size"
- `akp/data_source_akp_kargoagents_schema.go`: "Kaego instance ID" -> "Kargo instance ID"
- `akp/resource_akp_cluster_schema.go`: "an service account" -> "a service account"