### PR TITLE
fix: omit empty maintenance_mode_expiry from akp_cluster apply payloads

### DIFF
--- a/akp/resource_akp_cluster.go
+++ b/akp/resource_akp_cluster.go
@@ -403,6 +403,37 @@ func buildClusterApplyRequest(ctx context.Context, diagnostics *diag.Diagnostics
 	return applyReq
 }
 
+// pruneNormalizedEmptyClusterFields drops fields the control plane normalizes
+// away rather than persisting as an empty string.
+//
+// maintenanceModeExpiry is cleared by the control plane whenever maintenance
+// mode is disabled, so a cluster read back in that state carries "" in state.
+// Sending that empty string in a later apply payload fails the whole update:
+//
+//	invalid Cluster spec: parsing time "" as "2006-01-02T15:04:05Z07:00":
+//	cannot parse "" as "2006"
+//
+// Because maintenance mode is off by default, this makes any update to an
+// existing akp_cluster fail. Creates are unaffected -- the field is absent
+// rather than empty -- so the failure only appears once the resource exists.
+//
+// This mirrors pruneNormalizedEmptyKargoAgentFields, which already handles the
+// same field for akp_kargo_agent.
+func pruneNormalizedEmptyClusterFields(rawMap map[string]any) {
+	if rawMap == nil {
+		return
+	}
+
+	dataMap, _ := rawMap["data"].(map[string]any)
+	if len(dataMap) == 0 {
+		return
+	}
+
+	if value, ok := dataMap["maintenanceModeExpiry"].(string); ok && value == "" {
+		delete(dataMap, "maintenanceModeExpiry")
+	}
+}
+
 func buildClusters(ctx context.Context, diagnostics *diag.Diagnostics, cluster *types.Cluster) []*structpb.Struct {
 	var labels map[string]string
 	var annotations map[string]string
@@ -423,6 +454,7 @@ func buildClusters(ctx context.Context, diagnostics *diag.Diagnostics, cluster *
 		diagnostics.AddError("Client Error", "Unable to convert cluster spec to map")
 		return nil
 	}
+	pruneNormalizedEmptyClusterFields(rawMap)
 
 	clusterSize := cluster.Spec.Data.Size.ValueString()
 	var kustomizationStr string

--- a/akp/resource_akp_cluster_validation_test.go
+++ b/akp/resource_akp_cluster_validation_test.go
@@ -60,3 +60,84 @@ func TestValidateClusterConfigAllowsValidCombinations(t *testing.T) {
 
 	require.False(t, diags.HasError())
 }
+
+func TestPruneNormalizedEmptyClusterFields(t *testing.T) {
+	t.Run("drops empty maintenanceModeExpiry", func(t *testing.T) {
+		rawMap := map[string]any{
+			"data": map[string]any{
+				"maintenanceMode":       false,
+				"maintenanceModeExpiry": "",
+				"size":                  "large",
+			},
+		}
+
+		pruneNormalizedEmptyClusterFields(rawMap)
+
+		dataMap := rawMap["data"].(map[string]any)
+		_, present := dataMap["maintenanceModeExpiry"]
+		require.False(t, present, "empty maintenanceModeExpiry must not reach the apply payload")
+		require.Equal(t, "large", dataMap["size"], "unrelated fields must be preserved")
+		require.Equal(t, false, dataMap["maintenanceMode"], "maintenanceMode must be preserved")
+	})
+
+	t.Run("keeps a real maintenanceModeExpiry", func(t *testing.T) {
+		rawMap := map[string]any{
+			"data": map[string]any{
+				"maintenanceMode":       true,
+				"maintenanceModeExpiry": "2030-12-31T23:59:59Z",
+			},
+		}
+
+		pruneNormalizedEmptyClusterFields(rawMap)
+
+		dataMap := rawMap["data"].(map[string]any)
+		require.Equal(t, "2030-12-31T23:59:59Z", dataMap["maintenanceModeExpiry"])
+	})
+
+	t.Run("tolerates missing or empty input", func(t *testing.T) {
+		require.NotPanics(t, func() { pruneNormalizedEmptyClusterFields(nil) })
+		require.NotPanics(t, func() { pruneNormalizedEmptyClusterFields(map[string]any{}) })
+		require.NotPanics(t, func() {
+			pruneNormalizedEmptyClusterFields(map[string]any{"data": map[string]any{}})
+		})
+	})
+}
+
+// Regression test for the actual failure: the pruning must be wired into the
+// payload builder, not merely available as a helper. Without the call in
+// buildClusters, an empty maintenanceModeExpiry read back from the control
+// plane is sent on update and the API rejects the whole request with
+// `parsing time "" as "2006-01-02T15:04:05Z07:00"`.
+func TestBuildClustersOmitsEmptyMaintenanceModeExpiry(t *testing.T) {
+	cluster := &tfakptypes.Cluster{
+		Name:        tftypes.StringValue("test-cluster"),
+		Namespace:   tftypes.StringValue("akuity"),
+		Labels:      tftypes.MapNull(tftypes.StringType),
+		Annotations: tftypes.MapNull(tftypes.StringType),
+		Spec: &tfakptypes.ClusterSpec{
+			Data: tfakptypes.ClusterData{
+				Size: tftypes.StringValue("large"),
+				// What the control plane returns whenever maintenance mode is
+				// off, which is the default state for every cluster.
+				MaintenanceMode:       tftypes.BoolValue(false),
+				MaintenanceModeExpiry: tftypes.StringValue(""),
+			},
+		},
+	}
+
+	var diagnostics diag.Diagnostics
+	structs := buildClusters(t.Context(), &diagnostics, cluster)
+
+	require.False(t, diagnostics.HasError(), "unexpected diagnostics: %v", diagnostics)
+	require.Len(t, structs, 1)
+
+	payload := structs[0].AsMap()
+	spec, ok := payload["spec"].(map[string]any)
+	require.True(t, ok, "payload missing spec: %v", payload)
+	data, ok := spec["data"].(map[string]any)
+	require.True(t, ok, "spec missing data: %v", spec)
+
+	_, present := data["maintenanceModeExpiry"]
+	require.False(t, present,
+		"empty maintenanceModeExpiry must be omitted from the apply payload; the API rejects \"\" as a timestamp")
+}


### PR DESCRIPTION
Fixes #476

## Problem

Any update to an existing `akp_cluster` fails:

```
unable to create Argo CD instance: rpc error: code = InvalidArgument desc =
invalid Cluster spec: parsing time "" as "2006-01-02T15:04:05Z07:00":
cannot parse "" as "2006"
```

The control plane clears `maintenance_mode_expiry` whenever maintenance mode is disabled, so a cluster read back in that state carries `""` in Terraform state. `buildClusters` then serializes that empty string into the `ApplyInstance` payload via `TFToMapWithOverrides`, whose `types.String` case drops null and unknown values but **not** empty ones:

```go
case types.String:
    if v.IsNull() || v.IsUnknown() {
        return nil, false
    }
    return v.ValueString(), true
```

The API then rejects `""` as an RFC3339 timestamp.

Because maintenance mode is off by default, this makes `akp_cluster` effectively unupdatable. Creates are unaffected — the field is absent rather than empty — so the failure only appears once the resource exists in state. We hit it on every one of our clusters after importing existing registrations into a new state.

Neither `validateMaintenanceModeExpiry` nor `syncClusterMaintenanceMode` is involved; both already guard correctly with `isKnownNonEmptyString`.

## Fix

`akp_kargo_agent` already solves exactly this via `pruneNormalizedEmptyKargoAgentFields`, which names `maintenanceModeExpiry` explicitly:

```go
// The control plane normalizes these fields away instead of persisting an
// empty string. Omitting them from apply payloads prevents later updates
// from sending invalid empty values back to the API.
for _, key := range []string{"argocdNamespace", "maintenanceModeExpiry"} {
```

This adds the matching `pruneNormalizedEmptyClusterFields` for `akp_cluster` and calls it from `buildClusters`.

I deliberately did **not** widen the generic `types.String` conversion in `tftomap.go` — `""` is meaningful for other attributes, and mirroring the existing per-resource helper keeps the change scoped and consistent with how you already handle this.

## Tests

Two levels, in `akp/resource_akp_cluster_validation_test.go`:

- `TestPruneNormalizedEmptyClusterFields` — the helper: drops empty, preserves a real timestamp and unrelated fields, tolerates nil/empty input.
- `TestBuildClustersOmitsEmptyMaintenanceModeExpiry` — asserts on the built payload itself.

The second one is the important one. The bug was a *missing call site*, not a missing helper, so only a payload-level assertion catches a regression. Verified it fails without the fix:

```
=== WITHOUT the fix:
    Error:    Should be false
    Messages: empty maintenanceModeExpiry must be omitted from the apply
              payload; the API rejects "" as a timestamp
FAIL

=== WITH the fix:
ok  github.com/akuity/terraform-provider-akp/akp
```

`go build ./...`, `go vet ./akp/`, and `gofmt` are clean. The full suite has one pre-existing failure — `TestAccAll/Resources/ApiKey_CustomRoleClusterManifests` ("could not get test client") — which reproduces identically on unmodified `main` and needs live API credentials.

## Note on the `size` field

While debugging we noticed the control plane reports `size: CLUSTER_SIZE_LARGE` and `customAgentSizeConfig: null` for clusters configured with `size = "custom"`, storing the sizing only in the rendered `kustomization`. `inferCustomAgentSizeConfig` reconstructs this on read, but only when a plan with `size = "custom"` is present — so a bare import surfaces `large`. That's separate from this fix and I haven't touched it; happy to file it separately if useful.
